### PR TITLE
For PHP 7.1 compat use get_wp_details() instead of "version.php" include.

### DIFF
--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -40,7 +40,6 @@ Feature: Check for more recent versions
       1
       """
 
-  @less-than-php-7
   Scenario: No minor updates for an unlocalized WordPress release
     Given a WP install
 

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -44,6 +44,7 @@ Feature: Download WordPress
 
   Scenario: Verify release hash when downloading new version
     Given an empty directory
+    And an empty cache
 
     When I run `wp core download --version=4.4.1`
     Then STDOUT should contain:

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -29,8 +29,9 @@ Feature: Update WordPress core
       4.0
       """
 
-  # PHP 7.1 needs WP 3.9 (due to wp_check_php_mysql_versions(), see trac changeset [27257]).
-  @less-than-php-7.1
+  # PHP 7.1 needs WP 3.9 (due to wp_check_php_mysql_versions(), see trac changeset [27257]),
+  # and travis doesn't install mysql extension by default for PHP 7.0.
+  @less-than-php-7
   Scenario: Update to the latest minor release
     Given a WP install
 

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -1,20 +1,19 @@
 Feature: Update WordPress core
 
-  @less-than-php-7
   Scenario: Update from a ZIP file
     Given a WP install
 
-    When I run `wp core download --version=3.8 --force`
+    When I run `wp core download --version=3.9 --force`
     Then STDOUT should not be empty
 
     When I run `wp eval 'echo $GLOBALS["wp_version"];'`
     Then STDOUT should be:
       """
-      3.8
+      3.9
       """
 
-    When I run `wget http://wordpress.org/wordpress-3.9.zip --quiet`
-    And I run `wp core update wordpress-3.9.zip`
+    When I run `wget http://wordpress.org/wordpress-4.0.zip --quiet`
+    And I run `wp core update wordpress-4.0.zip`
     Then STDOUT should be:
       """
       Starting update...
@@ -27,10 +26,11 @@ Feature: Update WordPress core
     When I run `wp eval 'echo $GLOBALS["wp_version"];'`
     Then STDOUT should be:
       """
-      3.9
+      4.0
       """
 
-  @less-than-php-7
+  # PHP 7.1 needs WP 3.9 (due to wp_check_php_mysql_versions(), see trac changeset [27257]).
+  @less-than-php-7.1
   Scenario: Update to the latest minor release
     Given a WP install
 
@@ -55,12 +55,35 @@ Feature: Update WordPress core
       3.7.21
       """
 
-  @less-than-php-7
+  Scenario: Update to the latest minor release (PHP 7.1 compatible with WP >= 3.9)
+    Given a WP install
+
+    When I run `wp core download --version=3.9.9 --force`
+    Then STDOUT should not be empty
+
+    When I run `wp core update --minor`
+    Then STDOUT should contain:
+      """
+      Updating to version 3.9.19
+      """
+
+    When I run `wp core update --minor`
+    Then STDOUT should be:
+      """
+      Success: WordPress is at the latest minor release.
+      """
+
+    When I run `wp core version`
+    Then STDOUT should be:
+      """
+      3.9.19
+      """
+
   Scenario: Core update from cache
     Given a WP install
     And an empty cache
 
-    When I run `wp core update --version=3.8.1 --force`
+    When I run `wp core update --version=3.9.1 --force`
     Then STDOUT should not contain:
       """
       Using cached file
@@ -70,13 +93,13 @@ Feature: Update WordPress core
       Downloading
       """
 
-    When I run `wp core update --version=3.9 --force`
+    When I run `wp core update --version=4.0 --force`
     Then STDOUT should not be empty
 
-    When I run `wp core update --version=3.8.1 --force`
+    When I run `wp core update --version=3.9.1 --force`
     Then STDOUT should contain:
       """
-      Using cached file '{SUITE_CACHE_DIR}/core/wordpress-3.8.1-en_US.zip'...
+      Using cached file '{SUITE_CACHE_DIR}/core/wordpress-3.9.1-en_US.zip'...
       """
     And STDOUT should not contain:
       """
@@ -161,7 +184,6 @@ Feature: Update WordPress core
       wordpress-4.2.4-partial-1-en_US.zip
       """
 
-  @less-than-php-7
   Scenario: Make sure files are cleaned up
     Given a WP install
     When I run `wp core update --version=4.4 --force`
@@ -195,7 +217,6 @@ Feature: Update WordPress core
     When I run `wp post create --post_title='Test post' --porcelain`
     Then STDOUT should be a number
 
-  @less-than-php-7 @require-wp-4.0
   Scenario: Minor update on an unlocalized WordPress release
     Given a WP install
     And an empty cache
@@ -210,7 +231,7 @@ Feature: Update WordPress core
     Then STDOUT should contain:
       """
       Updating to version 4.0.18 (en_US)...
-      Descargando paquete de instalación desde https://downloads.wordpress.org/release/wordpress-4.0.16-partial-0.zip
+      Descargando paquete de instalación desde https://downloads.wordpress.org/release/wordpress-4.0.18-partial-0.zip
       """
     And STDOUT should contain:
       """

--- a/features/core.feature
+++ b/features/core.feature
@@ -77,7 +77,7 @@ Feature: Manage WordPress installation
       admin@example.com
       """
 
-    When I run `wp core install --url=localhost:8001 --title=Test --admin_user=wpcli --prompt=admin_email,admin_password < session`
+    When I run `wp core install --url=localhost:8001 --title=Test --admin_user=wpcli --prompt=admin_password,admin_email < session`
     Then STDOUT should not be empty
 
     When I run `wp eval 'echo home_url();'`

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -160,9 +160,8 @@ class Core_Command extends WP_CLI_Command {
 
 		$from_version = '';
 		if ( file_exists( $download_dir . 'wp-includes/version.php' ) ) {
-			global $wp_version;
-			require_once( $download_dir . 'wp-includes/version.php' );
-			$from_version = $wp_version;
+			$wp_details = self::get_wp_details( $download_dir );
+			$from_version = $wp_details['wp_version'];
 		}
 
 		WP_CLI::log( sprintf( 'Downloading WordPress %s (%s)...', $version, $locale ) );
@@ -774,8 +773,8 @@ EOT;
 	 *     @type string $wp_local_package The TinyMCE version.
 	 * }
 	 */
-	private static function get_wp_details() {
-		$versions_path = ABSPATH . 'wp-includes/version.php';
+	private static function get_wp_details( $abspath = ABSPATH ) {
+		$versions_path = $abspath . 'wp-includes/version.php';
 
 		if ( ! is_readable( $versions_path ) ) {
 			WP_CLI::error(
@@ -1022,9 +1021,10 @@ EOT;
 				}
 			} else {
 
+				$to_version = '';
 				if ( file_exists( ABSPATH . 'wp-includes/version.php' ) ) {
-					include( ABSPATH . 'wp-includes/version.php' );
-					$to_version = $wp_version;
+					$wp_details = self::get_wp_details();
+					$to_version = $wp_details['wp_version'];
 				}
 
 				$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', get_locale() );


### PR DESCRIPTION
Issue https://github.com/wp-cli/core-command/issues/12

Use `Core_Command::get_wp_details()` instead of including "wp-include/version.php" to set from/to versions, for PHP 7.1 compatibility, and use WP >= 3.9 for tests (except for one) for PHP >= 7 compatibility.

Also as mentioned in https://github.com/wp-cli/core-command/issues/8#issuecomment-303110064, update an old "4.0.16" version missed in https://github.com/wp-cli/core-command/pull/7 and remove the "require-wp-4.0" tag which was masking it from travis.

Also make sure cache is empty for "Verify release hash when downloading new version" test (probably only a run-locally issue).

Also address https://github.com/wp-cli/core-command/issues/10, misleading test prompt order, as it's trivial to fix.
