### PR TITLE
GH#11 --skip-config feature added

### DIFF
--- a/features/core-install.feature
+++ b/features/core-install.feature
@@ -184,3 +184,15 @@ Feature: Install WordPress core
       """
       Success: Network installed. Don't forget to set up rewrite rules.
       """
+
+  Scenario: Install WordPress multisite without adding multisite constants to wp-config file
+    Given an empty directory
+    And WP files
+    And wp-config.php
+    And a database
+
+    When I run `wp core multisite-install --url=foobar.org --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=password --skip-config`
+    Then STDOUT should contain:
+    """
+    Addition of multisite constants to 'wp-config.php' skipped. You need to add them manually:
+    """

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -640,7 +640,7 @@ EOT;
 
 			$wp_config_path = Utils\locate_wp_config();
 			if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-config' ) ) {
-				WP_CLI::log( "Addition of multisite constants to 'wp-config.php' skipped. You need to add them manually:" . PHP_EOL );
+				WP_CLI::log( "Addition of multisite constants to 'wp-config.php' skipped. You need to add them manually:" . PHP_EOL . $ms_config );
 			} elseif ( is_writable( $wp_config_path ) && self::modify_wp_config( $ms_config ) ) {
 				WP_CLI::log( "Added multisite constants to 'wp-config.php'." );
 			} else {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -446,6 +446,9 @@ class Core_Command extends WP_CLI_Command {
 	 * [--skip-email]
 	 * : Don't send an email notification to the new admin user.
 	 *
+	 * [--skip-config]
+	 * : Don't add multisite constants to wp-config.php.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp core multisite-install --title="Welcome to the WordPress" \
@@ -636,7 +639,9 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 EOT;
 
 			$wp_config_path = Utils\locate_wp_config();
-			if ( is_writable( $wp_config_path ) && self::modify_wp_config( $ms_config ) ) {
+			if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-config' ) ) {
+				WP_CLI::log( "Addition of multisite constants to 'wp-config.php' skipped. You need to add them manually:" . PHP_EOL );
+			} elseif ( is_writable( $wp_config_path ) && self::modify_wp_config( $ms_config ) ) {
 				WP_CLI::log( "Added multisite constants to 'wp-config.php'." );
 			} else {
 				WP_CLI::warning( "Multisite constants could not be written to 'wp-config.php'. You may need to add them manually:" . PHP_EOL . $ms_config );


### PR DESCRIPTION
--skip-config will avoid addition of multisite constants to wp-config.php file.