### PR TITLE
Add slash to --path. Make unlocalized minor update WP < 4 compat. Suppress notices.

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -18,7 +18,7 @@ Feature: Download WordPress
     And I run `cd inner && wp core download`
     Then the inner/wp-settings.php file should exist
 
-	When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=inner`
+    When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=inner`
     Then STDERR should be:
       """
       Error: WordPress files seem to already be present here.
@@ -233,3 +233,39 @@ Feature: Download WordPress
     Then save STDOUT as {VERSION}
     And the {SUITE_CACHE_DIR}/core/wordpress-latest-en_US.tar.gz file should not exist
     And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz file should exist
+
+  Scenario: Fail if path can't be created
+    Given an empty directory
+    And a non-directory-path file:
+    """
+    """
+
+    When I try `wp core download --path=non-directory-path`
+    Then STDERR should contain:
+    """
+    Failed to create directory
+    """
+    And STDERR should contain:
+    """
+    non-directory-path
+    """
+
+    When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=non-directory-path`
+    Then STDERR should contain:
+    """
+    Failed to create directory
+    """
+    And STDERR should contain:
+    """
+    non-directory-path
+    """
+
+    When I try `wp core download --path=/root-level-directory`
+    Then STDERR should contain:
+    """
+    Insufficient permission to create directory
+    """
+    And STDERR should contain:
+    """
+    root-level-directory
+    """

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -18,6 +18,12 @@ Feature: Download WordPress
     And I run `cd inner && wp core download`
     Then the inner/wp-settings.php file should exist
 
+    When I try `wp core download --path=inner`
+    Then STDERR should be:
+      """
+      Error: WordPress files seem to already be present here.
+      """
+
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=inner`
     Then STDERR should be:
       """

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -18,6 +18,12 @@ Feature: Download WordPress
     And I run `cd inner && wp core download`
     Then the inner/wp-settings.php file should exist
 
+	When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=inner`
+    Then STDERR should be:
+      """
+      Error: WordPress files seem to already be present here.
+      """
+
     # test core tarball cache
     When I run `wp core download --force`
     Then the wp-settings.php file should exist

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -269,3 +269,13 @@ Feature: Download WordPress
     """
     root-level-directory
     """
+
+    When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=/root-level-directory`
+    Then STDERR should contain:
+    """
+    Insufficient permission to create directory
+    """
+    And STDERR should contain:
+    """
+    root-level-directory
+    """

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -232,7 +232,10 @@ Feature: Update WordPress core
     Then STDOUT should contain:
       """
       Updating to version {WP_VERSION-4.0-latest} (en_US)...
-      Descargando paquete de instalación desde https://downloads.wordpress.org/release/wordpress-{WP_VERSION-4.0-latest}-partial-0.zip
+      """
+    And STDOUT should contain:
+      """
+      https://downloads.wordpress.org/release/wordpress-{WP_VERSION-4.0-latest}-partial-0.zip
       """
     And STDOUT should contain:
       """

--- a/features/core.feature
+++ b/features/core.feature
@@ -212,9 +212,13 @@ Feature: Manage WordPress installation
 
   Scenario: Install multisite from scratch, with MULTISITE already set in wp-config.php
     Given a WP multisite install
+    And a suppress-error-log.php file:
+      """
+      <?php ini_set( 'error_log', null );
+      """
     And I run `wp db reset --yes`
 
-    When I try `wp core is-installed`
+    When I try `wp --require=suppress-error-log.php core is-installed`
     Then the return code should be 1
 
     When I run `wp core multisite-install --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1`

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -117,7 +117,7 @@ class Core_Command extends WP_CLI_Command {
 	 */
 	public function download( $args, $assoc_args ) {
 
-		$download_dir = ! empty( $assoc_args['path'] ) ? $assoc_args['path'] : ABSPATH;
+		$download_dir = ! empty( $assoc_args['path'] ) ? ( rtrim( $assoc_args['path'], '/\//' ) . '/' ) : ABSPATH;
 		$wordpress_present = is_readable( $download_dir . 'wp-load.php' );
 
 		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && $wordpress_present )
@@ -129,8 +129,7 @@ class Core_Command extends WP_CLI_Command {
 			}
 
 			WP_CLI::log( sprintf( "Creating directory '%s'.", $download_dir ) );
-			$mkdir = \WP_CLI\Utils\is_windows() ? 'mkdir %s' : 'mkdir -p %s';
-			WP_CLI::launch( Utils\esc_cmd( $mkdir, $download_dir ) );
+			mkdir( $download_dir, 0777, true /*recursive*/ );
 		}
 
 		if ( ! is_writable( $download_dir ) ) {
@@ -1122,7 +1121,11 @@ EOT;
 				if ( $dry_run ) {
 					WP_CLI::success( "WordPress database will be upgraded from db version {$wp_current_db_version} to {$wp_db_version}." );
 				} else {
+					// WP upgrade isn't too fussy about generating MySQL warnings such as "Duplicate key name" during on upgrade so suppress.
+					$wpdb->suppress_errors();
+
 					wp_upgrade();
+
 					WP_CLI::success( "WordPress database upgraded successfully from db version {$wp_current_db_version} to {$wp_db_version}." );
 				}
 			} else {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -129,7 +129,7 @@ class Core_Command extends WP_CLI_Command {
 			}
 
 			WP_CLI::log( sprintf( "Creating directory '%s'.", $download_dir ) );
-			if ( ! mkdir( $download_dir, 0777, true /*recursive*/ ) ) {
+			if ( ! @mkdir( $download_dir, 0777, true /*recursive*/ ) ) {
 				$error = error_get_last();
 				WP_CLI::error( sprintf( "Failed to create directory '%s': %s.", $download_dir, $error['message'] ) );
 			}

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -129,7 +129,10 @@ class Core_Command extends WP_CLI_Command {
 			}
 
 			WP_CLI::log( sprintf( "Creating directory '%s'.", $download_dir ) );
-			mkdir( $download_dir, 0777, true /*recursive*/ );
+			if ( ! mkdir( $download_dir, 0777, true /*recursive*/ ) ) {
+				$error = error_get_last();
+				WP_CLI::error( sprintf( "Failed to create directory '%s': %s.", $download_dir, $error['message'] ) );
+			}
 		}
 
 		if ( ! is_writable( $download_dir ) ) {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1124,7 +1124,7 @@ EOT;
 				if ( $dry_run ) {
 					WP_CLI::success( "WordPress database will be upgraded from db version {$wp_current_db_version} to {$wp_db_version}." );
 				} else {
-					// WP upgrade isn't too fussy about generating MySQL warnings such as "Duplicate key name" during on upgrade so suppress.
+					// WP upgrade isn't too fussy about generating MySQL warnings such as "Duplicate key name" during an upgrade so suppress.
 					$wpdb->suppress_errors();
 
 					wp_upgrade();


### PR DESCRIPTION
Issue https://github.com/wp-cli/core-command/issues/20

Appends slash to `path` associative arg so `wp-load.php` check works.

Also in tests removes the Spanish from the "Minor update on an unlocalized WordPress release" scenario `core-update.feature:221` as this message only appears translated for WP >= 4.0. (Should a WP 3.7.11 test be added to Travis?)

Also suppresses warnings generated by `wp-db.php` during a WP upgrade.

Also suppresses `error_log` notices in the "Minor update on an unlocalized WordPress release" scenario `core.feature:213`.

Also replaces the shell `mkdir` with a PHP one.
