### PR TITLE
Fix rtrim trailingslashit literal.

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -253,7 +253,7 @@ Feature: Download WordPress
     """
     And STDERR should contain:
     """
-    non-directory-path
+    /non-directory-path/
     """
 
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=non-directory-path`
@@ -263,7 +263,17 @@ Feature: Download WordPress
     """
     And STDERR should contain:
     """
-    non-directory-path
+    non-directory-path/
+    """
+
+    When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=non-directory-path\\`
+    Then STDERR should contain:
+    """
+    Failed to create directory
+    """
+    And STDERR should contain:
+    """
+    non-directory-path/
     """
 
     When I try `wp core download --path=/root-level-directory`
@@ -273,7 +283,7 @@ Feature: Download WordPress
     """
     And STDERR should contain:
     """
-    root-level-directory
+    /root-level-directory/
     """
 
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=/root-level-directory`
@@ -283,5 +293,5 @@ Feature: Download WordPress
     """
     And STDERR should contain:
     """
-    root-level-directory
+    /root-level-directory/
     """

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -117,7 +117,7 @@ class Core_Command extends WP_CLI_Command {
 	 */
 	public function download( $args, $assoc_args ) {
 
-		$download_dir = ! empty( $assoc_args['path'] ) ? ( rtrim( $assoc_args['path'], '/\//' ) . '/' ) : ABSPATH;
+		$download_dir = ! empty( $assoc_args['path'] ) ? ( rtrim( $assoc_args['path'], '/\\' ) . '/' ) : ABSPATH;
 		$wordpress_present = is_readable( $download_dir . 'wp-load.php' );
 
 		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && $wordpress_present )


### PR DESCRIPTION
Fix mangled `rtrim()` literal introduced by me in https://github.com/wp-cli/core-command/pull/21. (Amazingly `'/\//'` does actually work as PHP just leaves unprocessed anything backslashed in a single quoted string except backslash and single quote!)

Adds test for WP_CLI_STRICT_ARGS_MODE case but not for non-WP_CLI_STRICT_ARGS_MODE case as it doesn't cater for backslash (yet - should introduce and use `Utils\trailingslashit()` on it in `Runner::set_wp_path()` I think).

Makes some of the `stderr` checks more explicit.
