### PR TITLE
Use `dist: precise` for PHP 5.3, `dist: trusty` for everything else

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: php
 
@@ -34,6 +35,7 @@ matrix:
     - php: 5.6
       env: WP_VERSION=trunk
     - php: 5.3
+      dist: precise
       env: WP_VERSION=latest
 
 before_install:


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/4218