### PR TITLE
Add skip content flag feature 

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -14,11 +14,6 @@ Feature: Download WordPress
     And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz file should exist
     And the {SUITE_CACHE_DIR}/core/wordpress-{WP_VERSION-latest}-en_US.tar.gz file should exist
 
-    When I run `wp core download --skip-content`
-    And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
-    Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-{WP_VERSION-latest}-without-content-en_US.zip file should exist
-
     When I run `mkdir inner`
     And I run `cd inner && wp core download`
     Then the inner/wp-settings.php file should exist
@@ -300,3 +295,25 @@ Feature: Download WordPress
     """
     /root-level-directory/
     """
+
+  Scenario: Core download without the wp-content dir
+    Given an empty directory
+    And an empty cache
+
+    When I run `wp core download --skip-content`
+    And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
+    Then the wp-settings.php file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-{WP_VERSION-latest}-without-content-en_US.zip file should exist
+
+
+  Scenario: Core download without the wp-content dir should error for non US locale
+    Given an empty directory
+    And an empty cache
+
+    When I run `wp core download --skip-content --locale=nl_NL`
+    Then STDOUT should contain:
+      """
+      Error: The skip content build is only available for the en_US locale.
+      """
+
+

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -14,6 +14,11 @@ Feature: Download WordPress
     And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz file should exist
     And the {SUITE_CACHE_DIR}/core/wordpress-{WP_VERSION-latest}-en_US.tar.gz file should exist
 
+    When I run `wp core download --skip-content`
+    And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION} without content
+    Then the wp-settings.php file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-{WP_VERSION-latest}-without-content-en_US.zip file should exist
+
     When I run `mkdir inner`
     And I run `cd inner && wp core download`
     Then the inner/wp-settings.php file should exist

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -303,8 +303,6 @@ Feature: Download WordPress
     When I run `wp core download --skip-content`
     And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
     Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-{WP_VERSION-latest}-without-content-en_US.zip file should exist
-
 
   Scenario: Core download without the wp-content dir should error for non US locale
     Given an empty directory

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -310,8 +310,8 @@ Feature: Download WordPress
     Given an empty directory
     And an empty cache
 
-    When I run `wp core download --skip-content --locale=nl_NL`
-    Then STDOUT should contain:
+    When I try `wp core download --skip-content --locale=nl_NL`
+    Then STDERR should contain:
       """
       Error: The skip content build is only available for the en_US locale.
       """
@@ -321,8 +321,8 @@ Feature: Download WordPress
     Given an empty directory
     And an empty cache
 
-    When I run `wp core download --skip-content --version=4.7`
-    Then STDOUT should contain:
+    When I try `wp core download --skip-content --version=4.7`
+    Then STDERR should contain:
       """
       Error: The skip content build is only available for the latest version.
       """

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -311,7 +311,7 @@ Feature: Download WordPress
     When I try `wp core download --skip-content --locale=nl_NL`
     Then STDERR should contain:
       """
-      Error: The skip content build is only available for the en_US locale.
+      Error: Skip content build is only available for the latest version.
       """
 
 

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -15,7 +15,7 @@ Feature: Download WordPress
     And the {SUITE_CACHE_DIR}/core/wordpress-{WP_VERSION-latest}-en_US.tar.gz file should exist
 
     When I run `wp core download --skip-content`
-    And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION} without content
+    And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
     Then the wp-settings.php file should exist
     And the {SUITE_CACHE_DIR}/core/wordpress-{WP_VERSION-latest}-without-content-en_US.zip file should exist
 

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -317,3 +317,14 @@ Feature: Download WordPress
       """
 
 
+  Scenario: Core download without the wp-content dir should error for non US locale
+    Given an empty directory
+    And an empty cache
+
+    When I run `wp core download --skip-content --version=4.7`
+    Then STDOUT should contain:
+      """
+      Error: The skip content build is only available for the latest version.
+      """
+
+

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -304,25 +304,26 @@ Feature: Download WordPress
     And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
     Then the wp-settings.php file should exist
 
+
   Scenario: Core download without the wp-content dir should error for non US locale
     Given an empty directory
     And an empty cache
 
     When I try `wp core download --skip-content --locale=nl_NL`
     Then STDERR should contain:
-      """
-      Error: Skip content build is only available for the latest version.
-      """
+    """
+    Skip content build is only available for the en_US locale.
+    """
 
 
-  Scenario: Core download without the wp-content dir should error for non US locale
+  Scenario: Core download without the wp-content dir should error if a version is set
     Given an empty directory
     And an empty cache
 
     When I try `wp core download --skip-content --version=4.7`
     Then STDERR should contain:
-      """
-      Error: The skip content build is only available for the latest version.
-      """
+    """
+    Skip content build is only available for the latest version.
+    """
 
 

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -109,7 +109,7 @@ class Core_Command extends WP_CLI_Command {
 	 * : Overwrites existing files, if present.
 	 *
 	 * [--skip-content]
-	 * : Download the latest version of WP without the default themes and plugins
+	 * : Download the latest version of WP without the default themes and plugins (en_US locale only)
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -108,6 +108,9 @@ class Core_Command extends WP_CLI_Command {
 	 * [--force]
 	 * : Overwrites existing files, if present.
 	 *
+	 * [--skip-content]
+	 * : Download the latest version of WP without the default themes and plugins
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp core download --locale=nl_NL
@@ -156,6 +159,12 @@ class Core_Command extends WP_CLI_Command {
 			}
 			$version = $offer['current'];
 			$download_url = str_replace( '.zip', '.tar.gz', $offer['download'] );
+		}
+
+		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) ) {
+			$offer = unserialize( self::_read( 'https://api.wordpress.org/core/version-check/1.6/' ) );
+			$download_url = $offer['offers'][0]["packages"]["no_content"];
+			$version = $offer['offers'][0]["current"].' without content';
 		}
 
 		if ( 'nightly' === $version && 'en_US' !== $locale ) {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -167,6 +167,10 @@ class Core_Command extends WP_CLI_Command {
 			$version = $offer['offers'][0]["current"].' without content';
 		}
 
+		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && 'en_US' !== $locale ) {
+			WP_CLI::error( 'The skip content build is only available for the en_US locale.' );
+		}
+
 		if ( 'nightly' === $version && 'en_US' !== $locale ) {
 			WP_CLI::error( 'Nightly builds are only available for the en_US locale.' );
 		}

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -162,7 +162,7 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && 'en_US' !== $locale ) {
-			WP_CLI::error( 'The skip content build is only available for the en_US locale.' );
+			WP_CLI::error( 'Skip content build is only available for the en_US locale.' );
 		}
 
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && isset( $assoc_args['version'] ) ) {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -161,14 +161,14 @@ class Core_Command extends WP_CLI_Command {
 			$download_url = str_replace( '.zip', '.tar.gz', $offer['download'] );
 		}
 
+		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && 'en_US' !== $locale ) {
+			WP_CLI::error( 'The skip content build is only available for the en_US locale.' );
+		}
+
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) ) {
 			$offer = unserialize( self::_read( 'https://api.wordpress.org/core/version-check/1.6/' ) );
 			$download_url = $offer['offers'][0]["packages"]["no_content"];
 			$version = $offer['offers'][0]["current"].' without content';
-		}
-
-		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && 'en_US' !== $locale ) {
-			WP_CLI::error( 'The skip content build is only available for the en_US locale.' );
 		}
 
 		if ( 'nightly' === $version && 'en_US' !== $locale ) {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -170,9 +170,11 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) ) {
-			$offer = unserialize( self::_read( 'https://api.wordpress.org/core/version-check/1.6/' ) );
-			$download_url = $offer['offers'][0]["packages"]["no_content"];
-			$version = $offer['offers'][0]["current"].' without content';
+			$response = Requests::get( 'https://api.wordpress.org/core/version-check/1.7/', null, array( 'timeout' => 30 ) );
+			if ( 200 === $response->status_code && ( $body = json_decode( $response->body ) ) && is_object( $body ) && isset( $body->offers ) && is_array( $body->offers ) ) {
+				$download_url = $body->offers[0]->packages->no_content;
+				$version = $body->offers[0]->version;
+			}
 		}
 
 		if ( 'nightly' === $version && 'en_US' !== $locale ) {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -166,14 +166,16 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && isset( $assoc_args['version'] ) ) {
-			WP_CLI::error( 'The skip content build is only available for the latest version.' );
+			WP_CLI::error( 'Skip content build is only available for the latest version.' );
 		}
 
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) ) {
 			$response = Requests::get( 'https://api.wordpress.org/core/version-check/1.7/', null, array( 'timeout' => 30 ) );
-			if ( 200 === $response->status_code && ( $body = json_decode( $response->body ) ) && is_object( $body ) && isset( $body->offers ) && is_array( $body->offers ) ) {
+			if ( 200 === $response->status_code && ( $body = json_decode( $response->body ) ) && is_object( $body ) && isset( $body->offers[0]->packages->no_content ) && is_array( $body->offers ) ) {
 				$download_url = $body->offers[0]->packages->no_content;
 				$version = $body->offers[0]->version;
+			} else {
+				WP_CLI::error( 'Skip content build is not available.' );
 			}
 		}
 

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -165,6 +165,10 @@ class Core_Command extends WP_CLI_Command {
 			WP_CLI::error( 'The skip content build is only available for the en_US locale.' );
 		}
 
+		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && isset( $assoc_args['version'] ) ) {
+			WP_CLI::error( 'The skip content build is only available for the latest version.' );
+		}
+
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) ) {
 			$offer = unserialize( self::_read( 'https://api.wordpress.org/core/version-check/1.6/' ) );
 			$download_url = $offer['offers'][0]["packages"]["no_content"];


### PR DESCRIPTION
Allow users to install WordPress without content eg: `wp core download --skip-content`
See these issues for context https://github.com/wp-cli/core-command/issues/36 & https://github.com/wp-cli/ideas/issues/59 

This is my first pass, please let me know what needs improvement. 

