### PR TITLE
Make use of 'halt_on_error' to catch error and release lock

### DIFF
--- a/src/WP_CLI/CoreUpgrader.php
+++ b/src/WP_CLI/CoreUpgrader.php
@@ -67,13 +67,18 @@ class CoreUpgrader extends \Core_Upgrader {
 			$headers = array( 'Accept' => 'application/json' );
 			$options = array(
 				'timeout'  => 600,  // 10 minutes ought to be enough for everybody.
-				'filename' => $temp
+				'filename' => $temp,
+				'throw_exception_on_error' => true,
 			);
 
 			$this->skin->feedback( 'downloading_package', $package );
 
 			/** @var \Requests_Response|null $req */
-			$req = Utils\http_request( 'GET', $package, null, $headers, $options );
+			try {
+				$req = Utils\http_request( 'GET', $package, null, $headers, $options );
+			} catch( \Exception $e ) {
+				return new \WP_Error( 'download_failed', $e->getMessage() );
+			}
 			if ( ! is_null( $req ) && $req->status_code !== 200 ) {
 				return new \WP_Error( 'download_failed', $this->strings['download_failed'] );
 			}

--- a/src/WP_CLI/CoreUpgrader.php
+++ b/src/WP_CLI/CoreUpgrader.php
@@ -66,9 +66,9 @@ class CoreUpgrader extends \Core_Upgrader {
 			 */
 			$headers = array( 'Accept' => 'application/json' );
 			$options = array(
-				'timeout'  => 600,  // 10 minutes ought to be enough for everybody.
-				'filename' => $temp,
-				'throw_exception_on_error' => true,
+				'timeout'       => 600,  // 10 minutes ought to be enough for everybody.
+				'filename'      => $temp,
+				'halt_on_error' => false,
 			);
 
 			$this->skin->feedback( 'downloading_package', $package );


### PR DESCRIPTION
Requires https://github.com/wp-cli/wp-cli/pull/4383

Fixes #35