### PR TITLE
Cleanup for `--skip-content` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ or success message when up to date.
 Download core WordPress files.
 
 ~~~
-wp core download [--path=<path>] [--locale=<locale>] [--version=<version>] [--force]
+wp core download [--path=<path>] [--locale=<locale>] [--version=<version>] [--skip-content] [--force]
 ~~~
 
 Downloads and extracts WordPress core files to the specified path. Uses
@@ -83,6 +83,9 @@ Subsequent uses of command will use the local cache if it still exists.
 
 	[--version=<version>]
 		Select which version you want to download. Accepts a version number, 'latest' or 'nightly'
+
+	[--skip-content]
+		Download the latest version of WP without the default themes and plugins (en_US locale only)
 
 	[--force]
 		Overwrites existing files, if present.

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -298,32 +298,28 @@ Feature: Download WordPress
 
   Scenario: Core download without the wp-content dir
     Given an empty directory
-    And an empty cache
 
     When I run `wp core download --skip-content`
-    And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
-    Then the wp-settings.php file should exist
-
+    Then STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+    And the wp-content directory should not exist
 
   Scenario: Core download without the wp-content dir should error for non US locale
     Given an empty directory
-    And an empty cache
 
     When I try `wp core download --skip-content --locale=nl_NL`
-    Then STDERR should contain:
-    """
-    Skip content build is only available for the en_US locale.
-    """
-
+    Then STDERR should be:
+      """
+      Error: Skip content build is only available for the en_US locale.
+      """
 
   Scenario: Core download without the wp-content dir should error if a version is set
     Given an empty directory
-    And an empty cache
 
     When I try `wp core download --skip-content --version=4.7`
     Then STDERR should contain:
-    """
-    Skip content build is only available for the latest version.
-    """
-
-
+      """
+      Skip content build is only available for the latest version.
+      """

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -169,11 +169,13 @@ class Core_Command extends WP_CLI_Command {
 			$download_url = str_replace( '.zip', '.tar.gz', $offer['download'] );
 		}
 
+		$no_content = '';
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) ) {
 			$response = Requests::get( 'https://api.wordpress.org/core/version-check/1.7/', null, array( 'timeout' => 30 ) );
 			if ( 200 === $response->status_code && ( $body = json_decode( $response->body ) ) && is_object( $body ) && isset( $body->offers[0]->packages->no_content ) && is_array( $body->offers ) ) {
 				$download_url = $body->offers[0]->packages->no_content;
 				$version = $body->offers[0]->version;
+				$no_content = 'no-content-';
 			} else {
 				WP_CLI::error( 'Skip content build is not available.' );
 			}
@@ -201,7 +203,7 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		$cache = WP_CLI::get_cache();
-		$cache_key = "core/wordpress-{$version}-{$locale}.{$extension}";
+		$cache_key = "core/wordpress-{$version}-{$no_content}{$locale}.{$extension}";
 		$cache_file = $cache->has($cache_key);
 
 		$bad_cache = false;

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -105,11 +105,11 @@ class Core_Command extends WP_CLI_Command {
 	 * [--version=<version>]
 	 * : Select which version you want to download. Accepts a version number, 'latest' or 'nightly'
 	 *
-	 * [--force]
-	 * : Overwrites existing files, if present.
-	 *
 	 * [--skip-content]
 	 * : Download the latest version of WP without the default themes and plugins (en_US locale only)
+	 *
+	 * [--force]
+	 * : Overwrites existing files, if present.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -146,6 +146,14 @@ class Core_Command extends WP_CLI_Command {
 
 		$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', 'en_US' );
 
+		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && 'en_US' !== $locale ) {
+			WP_CLI::error( 'Skip content build is only available for the en_US locale.' );
+		}
+
+		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && isset( $assoc_args['version'] ) ) {
+			WP_CLI::error( 'Skip content build is only available for the latest version.' );
+		}
+
 		if ( isset( $assoc_args['version'] ) && 'latest' !== $assoc_args['version'] ) {
 			$version = $assoc_args['version'];
 			$version = ( in_array( strtolower( $version ), array( 'trunk', 'nightly' ) ) ? 'nightly' : $version );
@@ -159,14 +167,6 @@ class Core_Command extends WP_CLI_Command {
 			}
 			$version = $offer['current'];
 			$download_url = str_replace( '.zip', '.tar.gz', $offer['download'] );
-		}
-
-		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && 'en_US' !== $locale ) {
-			WP_CLI::error( 'Skip content build is only available for the en_US locale.' );
-		}
-
-		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) && isset( $assoc_args['version'] ) ) {
-			WP_CLI::error( 'Skip content build is only available for the latest version.' );
 		}
 
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) ) {


### PR DESCRIPTION
* Cleanup tests for greater specificity.
* Move errors to an earlier position to prevent unnecessary code execution.
* Use the appropriate cache key name for `--skip-content`.
* Avoid duplicate API requests by executing code path earlier.

Fixes #36