### PR TITLE
Use `WP_CLI\Utils\http_request()` to fetch `skip-content` build

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -304,6 +304,7 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+    And the wp-includes directory should exist
     And the wp-content directory should not exist
 
   Scenario: Core download without the wp-content dir should error for non US locale

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -156,7 +156,7 @@ class Core_Command extends WP_CLI_Command {
 
 		$no_content = '';
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) ) {
-			$response = \WP_CLI\Utils\http_request( 'GET', 'https://api.wordpress.org/core/version-check/1.7/', null, array( 'timeout' => 30 ) );
+			$response = \WP_CLI\Utils\http_request( 'GET', 'https://api.wordpress.org/core/version-check/1.7/' );
 			if ( 200 === $response->status_code && ( $body = json_decode( $response->body ) ) && is_object( $body ) && isset( $body->offers[0]->packages->no_content ) && is_array( $body->offers ) ) {
 				$download_url = $body->offers[0]->packages->no_content;
 				$version = $body->offers[0]->version;

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -156,7 +156,7 @@ class Core_Command extends WP_CLI_Command {
 
 		$no_content = '';
 		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-content' ) ) {
-			$response = Requests::get( 'https://api.wordpress.org/core/version-check/1.7/', null, array( 'timeout' => 30 ) );
+			$response = \WP_CLI\Utils\http_request( 'GET', 'https://api.wordpress.org/core/version-check/1.7/', null, array( 'timeout' => 30 ) );
 			if ( 200 === $response->status_code && ( $body = json_decode( $response->body ) ) && is_object( $body ) && isset( $body->offers[0]->packages->no_content ) && is_array( $body->offers ) ) {
 				$download_url = $body->offers[0]->packages->no_content;
 				$version = $body->offers[0]->version;


### PR DESCRIPTION
Doing so ensures the SSL certificate is used as necessary, and provides
requisite exception catching.

From #37