### PR TITLE
Update tests enable error reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
 
 matrix:
   include:
+    - php: 7.2
+      env: WP_VERSION=nightly
     - php: 7.1
       env: WP_VERSION=latest
     - php: 7.0

--- a/bin/install-package-tests.sh
+++ b/bin/install-package-tests.sh
@@ -5,6 +5,7 @@ set -ex
 install_db() {
 	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
 	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
+	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 }
 
 install_db

--- a/features/bootstrap/Process.php
+++ b/features/bootstrap/Process.php
@@ -115,4 +115,20 @@ class Process {
 
 		return $r;
 	}
+
+	/**
+	 * Run the command, but throw an Exception on error.
+	 * Same as `run_check()` above, but checks the correct stderr.
+	 *
+	 * @return ProcessRun
+	 */
+	public function run_check_stderr() {
+		$r = $this->run();
+
+		if ( $r->return_code || ! empty( $r->stderr ) ) {
+			throw new \RuntimeException( $r );
+		}
+
+		return $r;
+	}
 }

--- a/features/bootstrap/support.php
+++ b/features/bootstrap/support.php
@@ -2,6 +2,12 @@
 
 // Utility functions used by Behat steps
 
+function assertRegExp( $regex, $actual ) {
+	if ( ! preg_match( $regex, $actual ) ) {
+		throw new Exception( "Actual value: " . var_export( $actual, true ) );
+	}
+}
+
 function assertEquals( $expected, $actual ) {
 	if ( $expected != $actual ) {
 		throw new Exception( "Actual value: " . var_export( $actual, true ) );

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -30,7 +30,9 @@ function extract_from_phar( $path ) {
 
 	register_shutdown_function(
 		function() use ( $tmp_path ) {
-			@unlink( $tmp_path );
+			if ( file_exists( $tmp_path ) ) {
+				unlink( $tmp_path );
+			}
 		}
 	);
 
@@ -58,7 +60,7 @@ function load_dependencies() {
 	}
 
 	if ( ! $has_autoload ) {
-		fputs( STDERR, "Internal error: Can't find Composer autoloader.\nTry running: composer install\n" );
+		fwrite( STDERR, "Internal error: Can't find Composer autoloader.\nTry running: composer install\n" );
 		exit( 3 );
 	}
 }
@@ -138,7 +140,7 @@ function find_file_upward( $files, $dir = null, $stop_check = null ) {
 	if ( is_null( $dir ) ) {
 		$dir = getcwd();
 	}
-	while ( @is_readable( $dir ) ) {
+	while ( is_readable( $dir ) ) {
 		// Stop walking up when the supplied callable returns true being passed the $dir
 		if ( is_callable( $stop_check ) && call_user_func( $stop_check, $dir ) ) {
 			return null;
@@ -166,7 +168,7 @@ function is_path_absolute( $path ) {
 		return true;
 	}
 
-	return $path[0] === '/';
+	return '/' === $path[0];
 }
 
 /**
@@ -227,12 +229,12 @@ function locate_wp_config() {
 	static $path;
 
 	if ( null === $path ) {
+		$path = false;
+
 		if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 			$path = ABSPATH . 'wp-config.php';
 		} elseif ( file_exists( ABSPATH . '../wp-config.php' ) && ! file_exists( ABSPATH . '/../wp-settings.php' ) ) {
 			$path = ABSPATH . '../wp-config.php';
-		} else {
-			$path = false;
 		}
 
 		if ( $path ) {
@@ -244,7 +246,9 @@ function locate_wp_config() {
 }
 
 function wp_version_compare( $since, $operator ) {
-	return version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), $since, $operator );
+	$wp_version = str_replace( '-src', '', $GLOBALS['wp_version'] );
+	$since = str_replace( '-src', '', $since );
+	return version_compare( $wp_version, $since, $operator );
 }
 
 /**
@@ -358,9 +362,9 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 	do {
 		$tmpfile = basename( $filename );
 		$tmpfile = preg_replace( '|\.[^.]*$|', '', $tmpfile );
-		$tmpfile .= '-' . substr( md5( rand() ), 0, 6 );
+		$tmpfile .= '-' . substr( md5( mt_rand() ), 0, 6 );
 		$tmpfile = $tmpdir . $tmpfile . '.tmp';
-		$fp = @fopen( $tmpfile, 'x' );
+		$fp = fopen( $tmpfile, 'xb' );
 		if ( ! $fp && is_writable( $tmpdir ) && file_exists( $tmpfile ) ) {
 			$tmpfile = '';
 			continue;
@@ -379,10 +383,10 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 
 	$editor = getenv( 'EDITOR' );
 	if ( ! $editor ) {
+		$editor = 'vi';
+
 		if ( isset( $_SERVER['OS'] ) && false !== strpos( $_SERVER['OS'], 'indows' ) ) {
 			$editor = 'notepad';
-		} else {
-			$editor = 'vi';
 		}
 	}
 
@@ -416,9 +420,9 @@ function mysql_host_to_cli_args( $raw_host ) {
 		list( $assoc_args['host'], $extra ) = $host_parts;
 		$extra = trim( $extra );
 		if ( is_numeric( $extra ) ) {
-			$assoc_args['port'] = intval( $extra );
+			$assoc_args['port'] = (int) $extra;
 			$assoc_args['protocol'] = 'tcp';
-		} elseif ( $extra !== '' ) {
+		} elseif ( '' !== $extra ) {
 			$assoc_args['socket'] = $extra;
 		}
 	} else {
@@ -436,7 +440,9 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 	}
 
 	if ( isset( $assoc_args['host'] ) ) {
+		//@codingStandardsIgnoreStart
 		$assoc_args = array_merge( $assoc_args, mysql_host_to_cli_args( $assoc_args['host'] ) );
+		//@codingStandardsIgnoreEnd
 	}
 
 	$pass = $assoc_args['pass'];
@@ -581,6 +587,7 @@ function replace_path_consts( $source, $path ) {
 function http_request( $method, $url, $data = null, $headers = array(), $options = array() ) {
 
 	$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+	$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
 	if ( inside_phar() ) {
 		// cURL can't read Phar archives
 		$options['verify'] = extract_from_phar(
@@ -594,17 +601,24 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 			}
 		}
 		if ( empty( $options['verify'] ) ) {
-			WP_CLI::error( 'Cannot find SSL certificate.' );
+			$error_msg = 'Cannot find SSL certificate.';
+			if ( $halt_on_error ) {
+				WP_CLI::error( $error_msg );
+			}
+			throw new \RuntimeException( $error_msg );
 		}
 	}
 
 	try {
-		$request = \Requests::request( $url, $headers, $data, $method, $options );
-		return $request;
+		return \Requests::request( $url, $headers, $data, $method, $options );
 	} catch ( \Requests_Exception $ex ) {
 		// CURLE_SSL_CACERT_BADFILE only defined for PHP >= 7.
 		if ( 'curlerror' !== $ex->getType() || ! in_array( curl_errno( $ex->getData() ), array( CURLE_SSL_CONNECT_ERROR, CURLE_SSL_CERTPROBLEM, 77 /*CURLE_SSL_CACERT_BADFILE*/ ), true ) ) {
-			\WP_CLI::error( sprintf( "Failed to get url '%s': %s.", $url, $ex->getMessage() ) );
+			$error_msg = sprintf( "Failed to get url '%s': %s.", $url, $ex->getMessage() );
+			if ( $halt_on_error ) {
+				WP_CLI::error( $error_msg );
+			}
+			throw new \RuntimeException( $error_msg, null, $ex );
 		}
 		// Handle SSL certificate issues gracefully
 		\WP_CLI::warning( sprintf( "Re-trying without verify after failing to get verified url '%s' %s.", $url, $ex->getMessage() ) );
@@ -612,7 +626,11 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 		try {
 			return \Requests::request( $url, $headers, $data, $method, $options );
 		} catch ( \Requests_Exception $ex ) {
-			\WP_CLI::error( sprintf( "Failed to get non-verified url '%s' %s.", $url, $ex->getMessage() ) );
+			$error_msg = sprintf( "Failed to get non-verified url '%s' %s.", $url, $ex->getMessage() );
+			if ( $halt_on_error ) {
+				WP_CLI::error( $error_msg );
+			}
+			throw new \RuntimeException( $error_msg, null, $ex );
 		}
 	}
 }
@@ -698,11 +716,13 @@ function get_named_sem_ver( $new_version, $original_version ) {
 
 	if ( ! is_null( $minor ) && Semver::satisfies( $new_version, "{$major}.{$minor}.x" ) ) {
 		return 'patch';
-	} elseif ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
-		return 'minor';
-	} else {
-		return 'major';
 	}
+
+	if ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
+		return 'minor';
+	}
+
+	return 'major';
 }
 
 /**
@@ -770,16 +790,16 @@ function get_temp_dir() {
 		return $temp;
 	}
 
+	$temp = '/tmp/';
+
 	// `sys_get_temp_dir()` introduced PHP 5.2.1.
 	if ( $try = sys_get_temp_dir() ) {
 		$temp = trailingslashit( $try );
 	} elseif ( $try = ini_get( 'upload_tmp_dir' ) ) {
 		$temp = trailingslashit( $try );
-	} else {
-		$temp = '/tmp/';
 	}
 
-	if ( ! @is_writable( $temp ) ) {
+	if ( ! is_writable( $temp ) ) {
 		\WP_CLI::warning( "Temp directory isn't writable: {$temp}" );
 	}
 
@@ -813,6 +833,18 @@ function parse_ssh_url( $url, $component = -1 ) {
 			$bits[ $key ] = $matches[ $i ];
 		}
 	}
+
+	// Find the hostname from `vagrant ssh-config` automatically.
+	if ( preg_match( '/^vagrant:?/', $url ) ) {
+		if ( 'vagrant' === $bits['host'] && empty( $bits['scheme'] ) ) {
+			$ssh_config = shell_exec( 'vagrant ssh-config 2>/dev/null' );
+			if ( preg_match( '/Host\s(.+)/', $ssh_config, $matches ) ) {
+				$bits['scheme'] = 'vagrant';
+				$bits['host']   = $matches[1];
+			}
+		}
+	}
+
 	switch ( $component ) {
 		case PHP_URL_SCHEME:
 			return isset( $bits['scheme'] ) ? $bits['scheme'] : null;
@@ -835,25 +867,28 @@ function parse_ssh_url( $url, $component = -1 ) {
  * @access public
  * @category Input
  *
- * @param string  $noun      Resource being affected (e.g. plugin)
- * @param string  $verb      Type of action happening to the noun (e.g. activate)
- * @param integer $total     Total number of resource being affected.
- * @param integer $successes Number of successful operations.
- * @param integer $failures  Number of failures.
+ * @param string       $noun      Resource being affected (e.g. plugin)
+ * @param string       $verb      Type of action happening to the noun (e.g. activate)
+ * @param integer      $total     Total number of resource being affected.
+ * @param integer      $successes Number of successful operations.
+ * @param integer      $failures  Number of failures.
+ * @param null|integer $skips     Optional. Number of skipped operations. Default null (don't show skips).
  */
-function report_batch_operation_results( $noun, $verb, $total, $successes, $failures ) {
+function report_batch_operation_results( $noun, $verb, $total, $successes, $failures, $skips = null ) {
 	$plural_noun = $noun . 's';
 	$past_tense_verb = past_tense_verb( $verb );
 	$past_tense_verb_upper = ucfirst( $past_tense_verb );
 	if ( $failures ) {
+		$failed_skipped_message = null === $skips ? '' : " ({$failures} failed" . ( $skips ? ", {$skips} skipped" : '' ) . ')';
 		if ( $successes ) {
-			WP_CLI::error( "Only {$past_tense_verb} {$successes} of {$total} {$plural_noun}." );
+			WP_CLI::error( "Only {$past_tense_verb} {$successes} of {$total} {$plural_noun}{$failed_skipped_message}." );
 		} else {
-			WP_CLI::error( "No {$plural_noun} {$past_tense_verb}." );
+			WP_CLI::error( "No {$plural_noun} {$past_tense_verb}{$failed_skipped_message}." );
 		}
 	} else {
-		if ( $successes ) {
-			WP_CLI::success( "{$past_tense_verb_upper} {$successes} of {$total} {$plural_noun}." );
+		$skipped_message = $skips ? " ({$skips} skipped)" : '';
+		if ( $successes || $skips ) {
+			WP_CLI::success( "{$past_tense_verb_upper} {$successes} of {$total} {$plural_noun}{$skipped_message}." );
 		} else {
 			$message = $total > 1 ? ucfirst( $plural_noun ) : ucfirst( $noun );
 			WP_CLI::success( "{$message} already {$past_tense_verb}." );
@@ -876,7 +911,7 @@ function parse_str_to_argv( $arguments ) {
 	$argv = array_map(
 		function( $arg ) {
 			foreach ( array( '"', "'" ) as $char ) {
-				if ( $char === substr( $arg, 0, 1 ) && $char === substr( $arg, -1 ) ) {
+				if ( substr( $arg, 0, 1 ) === $char && substr( $arg, -1 ) === $char ) {
 					$arg = substr( $arg, 1, -1 );
 					break;
 				}
@@ -916,14 +951,15 @@ function basename( $path, $suffix = '' ) {
  *
  * @return bool
  */
+// @codingStandardsIgnoreLine
 function isPiped() {
 	$shellPipe = getenv( 'SHELL_PIPE' );
 
-	if ( $shellPipe !== false ) {
+	if ( false !== $shellPipe ) {
 		return filter_var( $shellPipe, FILTER_VALIDATE_BOOLEAN );
-	} else {
-		return (function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ));
 	}
+
+	return (function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ));
 }
 
 /**
@@ -992,9 +1028,11 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 					}
 					$current++;
 				} else {
-					if ( ( '}' === $pattern[ $current ] && $depth-- === 0 ) || ( ',' === $pattern[ $current ] && 0 === $depth ) ) {
+					if ( ( '}' === $pattern[ $current ] && 0 === $depth-- ) || ( ',' === $pattern[ $current ] && 0 === $depth ) ) {
 						break;
-					} elseif ( '{' === $pattern[ $current++ ] ) {
+					}
+
+					if ( '{' === $pattern[ $current++ ] ) {
 						$depth++;
 					}
 				}
@@ -1038,7 +1076,7 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 					. substr( $pattern, $p, $next - $p )
 					. substr( $pattern, $rest + 1 );
 
-		if ( ( $result = glob_brace( $subpattern ) ) ) {
+		if ( $result = glob_brace( $subpattern ) ) {
 			$paths = array_merge( $paths, $result );
 		}
 
@@ -1070,6 +1108,31 @@ function glob_brace( $pattern, $dummy_flags = null ) {
  * @return string
  */
 function get_suggestion( $target, array $options, $threshold = 2 ) {
+
+	$suggestion_map = array(
+		'check' => 'check-update',
+		'clear' => 'flush',
+		'decrement' => 'decr',
+		'del' => 'delete',
+		'directory' => 'dir',
+		'exec' => 'eval',
+		'exec-file' => 'eval-file',
+		'increment' => 'incr',
+		'language' => 'locale',
+		'lang' => 'locale',
+		'new' => 'create',
+		'number' => 'count',
+		'remove' => 'delete',
+		'regen' => 'regenerate',
+		'rep' => 'replace',
+		'repl' => 'replace',
+		'v' => 'version',
+	);
+
+	if ( array_key_exists( $target, $suggestion_map ) ) {
+		return $suggestion_map[ $target ];
+	}
+
 	if ( empty( $options ) ) {
 		return '';
 	}
@@ -1217,4 +1280,41 @@ function past_tense_verb( $verb ) {
 		$verb .= $last;
 	}
 	return $verb . 'ed';
+}
+
+/**
+ * Get the path to the PHP binary used when executing WP-CLI.
+ *
+ * Environment values permit specific binaries to be indicated.
+ *
+ * @access public
+ * @category System
+ *
+ * @return string
+ */
+function get_php_binary() {
+	if ( $wp_cli_php_used = getenv( 'WP_CLI_PHP_USED' ) ) {
+		return $wp_cli_php_used;
+	}
+
+	if ( $wp_cli_php = getenv( 'WP_CLI_PHP' ) ) {
+		return $wp_cli_php;
+	}
+
+	// Available since PHP 5.4.
+	if ( defined( 'PHP_BINARY' ) ) {
+		return PHP_BINARY;
+	}
+
+	// @codingStandardsIgnoreLine
+	if ( @is_executable( PHP_BINDIR . '/php' ) ) {
+		return PHP_BINDIR . '/php';
+	}
+
+	// @codingStandardsIgnoreLine
+	if ( is_windows() && @is_executable( PHP_BINDIR . '/php.exe' ) ) {
+		return PHP_BINDIR . '/php.exe';
+	}
+
+	return 'php';
 }

--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -43,11 +43,13 @@ Feature: Check for more recent versions
   Scenario: No minor updates for an unlocalized WordPress release
     Given a WP install
 
-    When I run `wp core download --version=4.0 --locale=es_ES --force`
+    # If current WP_VERSION is nightly, trunk or old then from checksums might not exist, so STDERR may or may not be empty.
+    When I try `wp core download --version=4.0 --locale=es_ES --force`
     Then STDOUT should contain:
       """
       Success: WordPress downloaded.
       """
+    And the return code should be 0
 
     When I run `wp core check-update --minor`
     Then STDOUT should be a table containing rows:

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -6,7 +6,11 @@ Feature: Download WordPress
 
     When I try `wp core is-installed`
     Then the return code should be 1
-    And STDERR should not be empty
+    And STDERR should contain:
+      """
+      Error: This does not seem to be a WordPress install.
+      """
+    And STDOUT should be empty
 
     When I run `wp core download`
     And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
@@ -23,12 +27,14 @@ Feature: Download WordPress
       """
       Error: WordPress files seem to already be present here.
       """
+    And the return code should be 1
 
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=inner`
     Then STDERR should be:
       """
       Error: WordPress files seem to already be present here.
       """
+    And the return code should be 1
 
     # test core tarball cache
     When I run `wp core download --force`
@@ -54,6 +60,7 @@ Feature: Download WordPress
       """
       Error: Release not found.
       """
+    And the return code should be 1
 
   Scenario: Verify release hash when downloading new version
     Given an empty directory
@@ -91,6 +98,7 @@ Feature: Download WordPress
       """
       Error: WordPress files seem to already be present here.
       """
+    And the return code should be 1
 
   Scenario: Make sure files are cleaned up
     Given an empty directory
@@ -114,7 +122,7 @@ Feature: Download WordPress
     Given an empty directory
     And an empty cache
 
-    When I run `wp core download --version=nightly`
+    When I try `wp core download --version=nightly`
     Then the wp-settings.php file should exist
     And the {SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip file should not exist
     And STDOUT should contain:
@@ -129,21 +137,31 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+    And the return code should be 0
 
     # we shouldn't cache nightly builds
-    When I run `wp core download --version=nightly --force`
+    When I try `wp core download --version=nightly --force`
     Then the wp-settings.php file should exist
     And STDOUT should not contain:
     """
     Using cached file '{SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip'...
     """
+    And STDERR should contain:
+      """
+      Warning: md5 hash checks are not available for nightly downloads.
+      """
+    And STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+    And the return code should be 0
 
   Scenario: Installing nightly over an existing install
     Given an empty directory
     And an empty cache
     When I run `wp core download --version=4.5.3`
     Then the wp-settings.php file should exist
-    When I run `wp core download --version=nightly --force`
+    When I try `wp core download --version=nightly --force`
     Then STDERR should not contain:
       """
       Warning: Failed to find WordPress version. Please cleanup files manually.
@@ -156,16 +174,22 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+    And the return code should be 0
 
   Scenario: Installing a version over nightly
     Given an empty directory
     And an empty cache
-    When I run `wp core download --version=nightly`
+    When I try `wp core download --version=nightly`
     Then the wp-settings.php file should exist
     And STDERR should not contain:
       """
       Warning: Failed to find WordPress version. Please cleanup files manually.
       """
+    And STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+    And the return code should be 0
 
     When I run `wp core download --version=4.3.2 --force`
     Then the wp-includes/rest-api.php file should not exist
@@ -178,7 +202,7 @@ Feature: Download WordPress
   Scenario: Trunk is an alias for nightly
     Given an empty directory
     And an empty cache
-    When I run `wp core download --version=trunk`
+    When I try `wp core download --version=trunk`
     Then the wp-settings.php file should exist
     And STDOUT should contain:
       """
@@ -192,6 +216,7 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+    And the return code should be 0
 
   Scenario: Installing nightly for a non-default locale
     Given an empty directory
@@ -255,6 +280,7 @@ Feature: Download WordPress
     """
     /non-directory-path/
     """
+    And the return code should be 1
 
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=non-directory-path`
     Then STDERR should contain:
@@ -265,6 +291,7 @@ Feature: Download WordPress
     """
     non-directory-path/
     """
+    And the return code should be 1
 
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=non-directory-path\\`
     Then STDERR should contain:
@@ -275,6 +302,7 @@ Feature: Download WordPress
     """
     non-directory-path/
     """
+    And the return code should be 1
 
     When I try `wp core download --path=/root-level-directory`
     Then STDERR should contain:
@@ -285,6 +313,7 @@ Feature: Download WordPress
     """
     /root-level-directory/
     """
+    And the return code should be 1
 
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp core download --path=/root-level-directory`
     Then STDERR should contain:
@@ -295,6 +324,7 @@ Feature: Download WordPress
     """
     /root-level-directory/
     """
+    And the return code should be 1
 
   Scenario: Core download without the wp-content dir
     Given an empty directory
@@ -315,6 +345,7 @@ Feature: Download WordPress
       """
       Error: Skip content build is only available for the en_US locale.
       """
+    And the return code should be 1
 
   Scenario: Core download without the wp-content dir should error if a version is set
     Given an empty directory
@@ -324,3 +355,4 @@ Feature: Download WordPress
       """
       Skip content build is only available for the latest version.
       """
+    And the return code should be 1

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -143,9 +143,9 @@ Feature: Download WordPress
     When I try `wp core download --version=nightly --force`
     Then the wp-settings.php file should exist
     And STDOUT should not contain:
-    """
-    Using cached file '{SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip'...
-    """
+      """
+      Using cached file '{SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip'...
+      """
     And STDERR should contain:
       """
       Warning: md5 hash checks are not available for nightly downloads.
@@ -164,11 +164,11 @@ Feature: Download WordPress
     When I try `wp core download --version=nightly --force`
     Then STDERR should not contain:
       """
-      Warning: Failed to find WordPress version. Please cleanup files manually.
+      Failed to find WordPress version
       """
     And STDERR should contain:
       """
-      Warning: Failed to fetch checksums. Please cleanup files manually.
+      Warning: Checksums not available for WordPress nightly/en_US. Please cleanup files manually.
       """
     And STDOUT should contain:
       """

--- a/features/core-install.feature
+++ b/features/core-install.feature
@@ -159,7 +159,8 @@ Feature: Install WordPress core
     And wp-config.php
     And a database
 
-    When I run `wp core install --url=localhost:8001 --title=Test --admin_user=wpcli --admin_email=wpcli@example.org`
+    # Old versions of WP can generate wpdb database errors if the WP tables don't exist, so STDERR may or may not be empty
+    When I try `wp core install --url=localhost:8001 --title=Test --admin_user=wpcli --admin_email=wpcli@example.org`
     Then STDOUT should contain:
       """
       Admin password:
@@ -168,6 +169,7 @@ Feature: Install WordPress core
       """
       Success: WordPress installed successfully.
       """
+    And the return code should be 0
 
   Scenario: Install WordPress multisite without specifying the password
     Given an empty directory
@@ -175,7 +177,8 @@ Feature: Install WordPress core
     And wp-config.php
     And a database
 
-    When I run `wp core multisite-install --url=foobar.org --title=Test --admin_user=wpcli --admin_email=admin@example.com`
+    # Old versions of WP can generate wpdb database errors if the WP tables don't exist, so STDERR may or may not be empty
+    When I try `wp core multisite-install --url=foobar.org --title=Test --admin_user=wpcli --admin_email=admin@example.com`
     Then STDOUT should contain:
       """
       Admin password:
@@ -184,6 +187,7 @@ Feature: Install WordPress core
       """
       Success: Network installed. Don't forget to set up rewrite rules (and a .htaccess file, if using Apache).
       """
+    And the return code should be 0
 
   Scenario: Install WordPress multisite without adding multisite constants to wp-config file
     Given an empty directory

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -19,7 +19,7 @@ Feature: Update WordPress core
       Starting update...
       Unpacking the update...
       Cleaning up files...
-      No files found that need cleaned up.
+      No files found that need cleaning up.
       Success: WordPress updated successfully.
       """
 
@@ -245,13 +245,16 @@ Feature: Update WordPress core
     Given a WP install
     And an empty cache
 
-    When I run `wp core download --version=4.0 --locale=es_ES --force`
+    # If current WP_VERSION is nightly, trunk or old then from checksums might not exist, so STDERR may or may not be empty.
+    When I try `wp core download --version=4.0 --locale=es_ES --force`
     Then STDOUT should contain:
       """
       Success: WordPress downloaded.
       """
+    And the return code should be 0
 
     # No checksums available for this WP version/locale
+	Given I run `wp option set WPLANG es_ES`
     When I try `wp core update --minor`
     Then STDOUT should contain:
       """
@@ -265,9 +268,9 @@ Feature: Update WordPress core
       """
       Success: WordPress updated successfully.
       """
-    And STDERR should contain:
+    And STDERR should be:
       """
-      Warning: Failed to fetch checksums. Please cleanup files manually.
+      Warning: Checksums not available for WordPress {WP_VERSION-4.0-latest}/es_ES. Please cleanup files manually.
       """
     And the return code should be 0
 

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -254,7 +254,7 @@ Feature: Update WordPress core
     And the return code should be 0
 
     # No checksums available for this WP version/locale
-	Given I run `wp option set WPLANG es_ES`
+    Given I run `wp option set WPLANG es_ES`
     When I try `wp core update --minor`
     Then STDOUT should contain:
       """

--- a/features/core.feature
+++ b/features/core.feature
@@ -346,11 +346,13 @@ Feature: Manage WordPress installation
     And the wp/wp-blog-header.php file should exist
 
     When I run `wp db create`
-    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com --skip-email`
+	# @broken: This is causing issues on sending email on Travis for some reason so allow non-empty STDERR for the moment.
+    And I try `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com`
     Then STDOUT should contain:
       """
       Success: WordPress installed successfully.
       """
+    And the return code should be 0
 
     When I run `wp option get home`
     Then STDOUT should be:

--- a/features/core.feature
+++ b/features/core.feature
@@ -346,7 +346,7 @@ Feature: Manage WordPress installation
     And the wp/wp-blog-header.php file should exist
 
     When I run `wp db create`
-    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com`
+    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com --skip-email`
     Then STDOUT should contain:
       """
       Success: WordPress installed successfully.

--- a/features/core.feature
+++ b/features/core.feature
@@ -346,13 +346,12 @@ Feature: Manage WordPress installation
     And the wp/wp-blog-header.php file should exist
 
     When I run `wp db create`
-	# @broken: This is causing issues on sending email on Travis for some reason so allow non-empty STDERR for the moment.
-    And I try `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com`
+    # extra/no-mail.php not present as mu-plugin so skip sending email else will fail on Travis with "sh: 1: -t: not found"
+    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com --skip-email`
     Then STDOUT should contain:
       """
       Success: WordPress installed successfully.
       """
-    And the return code should be 0
 
     When I run `wp option get home`
     Then STDOUT should be:

--- a/features/core.feature
+++ b/features/core.feature
@@ -216,7 +216,11 @@ Feature: Manage WordPress installation
 
     When I try `wp core is-installed`
     Then the return code should be 1
-    And STDERR should be empty
+    # WP will produce wpdb database errors in `get_sites()` on loading if the WP tables don't exist
+    And STDERR should contain:
+      """
+      WordPress database error Table
+      """
 
     When I run `wp core multisite-install --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1`
     Then STDOUT should not be empty
@@ -342,8 +346,11 @@ Feature: Manage WordPress installation
     And the wp/wp-blog-header.php file should exist
 
     When I run `wp db create`
-    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com --skip-email`
-    Then STDOUT should not be empty
+    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com`
+    Then STDOUT should contain:
+      """
+      Success: WordPress installed successfully.
+      """
 
     When I run `wp option get home`
     Then STDOUT should be:

--- a/features/core.feature
+++ b/features/core.feature
@@ -129,7 +129,7 @@ Feature: Manage WordPress installation
       false
       """
 
-    When I run `wp eval 'var_export( function_exists( 'media_handle_upload' ) );'`
+    When I run `wp eval 'var_export( function_exists( "media_handle_upload" ) );'`
     Then STDOUT should be:
       """
       true
@@ -238,6 +238,7 @@ Feature: Manage WordPress installation
       """
       Error: Multisite with subdomains cannot be configured when domain is 'localhost'.
       """
+    And the return code should be 1
 
   Scenario: Custom wp-content directory
     Given a WP install
@@ -294,6 +295,7 @@ Feature: Manage WordPress installation
       """
       Error: WordPress files seem to already be present here.
       """
+    And the return code should be 1
 
   Scenario: Install WordPress in a subdirectory
     Given an empty directory
@@ -340,7 +342,7 @@ Feature: Manage WordPress installation
     And the wp/wp-blog-header.php file should exist
 
     When I run `wp db create`
-    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com`
+    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com --skip-email`
     Then STDOUT should not be empty
 
     When I run `wp option get home`
@@ -359,7 +361,7 @@ Feature: Manage WordPress installation
     Given a WP install
     And "That's all" replaced with "C'est tout" in the wp-config.php file
 
-    When I run `wp core multisite-convert`
+    When I try `wp core multisite-convert`
     Then STDOUT should be:
       """
       Set up multisite database tables.
@@ -369,3 +371,4 @@ Feature: Manage WordPress installation
       """
       Warning: Multisite constants could not be written to 'wp-config.php'. You may need to add them manually:
       """
+    And the return code should be 0

--- a/features/core.feature
+++ b/features/core.feature
@@ -346,7 +346,7 @@ Feature: Manage WordPress installation
     And the wp/wp-blog-header.php file should exist
 
     When I run `wp db create`
-    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com --skip-email`
+    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com`
     Then STDOUT should contain:
       """
       Success: WordPress installed successfully.

--- a/features/core.feature
+++ b/features/core.feature
@@ -212,14 +212,11 @@ Feature: Manage WordPress installation
 
   Scenario: Install multisite from scratch, with MULTISITE already set in wp-config.php
     Given a WP multisite install
-    And a suppress-error-log.php file:
-      """
-      <?php ini_set( 'error_log', null );
-      """
     And I run `wp db reset --yes`
 
-    When I try `wp --require=suppress-error-log.php core is-installed`
+    When I try `wp core is-installed`
     Then the return code should be 1
+    And STDERR should be empty
 
     When I run `wp core multisite-install --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1`
     Then STDOUT should not be empty

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -3,9 +3,9 @@
 use Behat\Gherkin\Node\PyStringNode,
     Behat\Gherkin\Node\TableNode;
 
-$steps->Then( '/^the return code should be (\d+)$/',
-	function ( $world, $return_code ) {
-		if ( $return_code != $world->result->return_code ) {
+$steps->Then( '/^the return code should( not)? be (\d+)$/',
+	function ( $world, $not, $return_code ) {
+		if ( ( ! $not && $return_code != $world->result->return_code ) || ( $not && $return_code == $world->result->return_code ) ) {
 			throw new RuntimeException( $world->result );
 		}
 	}
@@ -153,7 +153,7 @@ $steps->Then( '/^(STDOUT|STDERR) should be a version string (<|<=|>|>=|==|=|!=|<
 			throw new Exception( $world->result );
 		}
 	}
-);	
+);
 
 $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|not contain:)$/',
 	function ( $world, $path, $type, $action, $expected = null ) {
@@ -197,6 +197,25 @@ $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|
 			}
 			checkString( $contents, $expected, $action );
 		}
+	}
+);
+
+$steps->Then( '/^the contents of the (.+) file should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
+	function ( $world, $path, $expected ) {
+		$path = $world->replace_variables( $path );
+		// If it's a relative path, make it relative to the current test dir
+		if ( '/' !== $path[0] ) {
+			$path = $world->variables['RUN_DIR'] . "/$path";
+		}
+		$contents = file_get_contents( $path );
+		assertRegExp( $expected, $contents );
+	}
+);
+
+$steps->Then( '/^(STDOUT|STDERR) should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
+	function ( $world, $stream, $expected ) {
+		$stream = strtolower( $stream );
+		assertRegExp( $expected, $world->result->$stream );
 	}
 );
 

--- a/features/steps/when.php
+++ b/features/steps/when.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Node\PyStringNode,
 
 function invoke_proc( $proc, $mode ) {
 	$map = array(
-		'run' => 'run_check',
+		'run' => 'run_check_stderr',
 		'try' => 'run'
 	);
 	$method = $map[ $mode ];

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -44,8 +44,10 @@ $skip_tags = array_merge(
 	version_tags( 'less-than-php', PHP_VERSION, '>' )
 );
 
-# Skip Github API tests by default because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
-$skip_tags[] = '@github-api';
+# Skip Github API tests if `GITHUB_TOKEN` not available because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
+if ( ! getenv( 'GITHUB_TOKEN' ) ) {
+	$skip_tags[] = '@github-api';
+}
 
 # Skip tests known to be broken.
 $skip_tags[] = '@broken';


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/4515

X test breakages locally run -> try. 

In `Core_Command`:

Avoids PHP notice for unset `$_SERVER['HTTP']` in `wp_guess_url()` when called via `wp_upgrade()` in `Core_Command::update_db()`.

Skips new WP 4.9 "Notice of Admin Email Change" email if `--skip-email`.

Adds more detailed messages if checksum request fails that might help explain `checksum-command` build fail in https://github.com/wp-cli/checksum-command/pull/16#issuecomment-345018139.