### PR TITLE
Ignore SSL trigger_error in WP get_core_checksums() on core upgrade.

### DIFF
--- a/src/WP_CLI/CoreUpgrader.php
+++ b/src/WP_CLI/CoreUpgrader.php
@@ -89,4 +89,52 @@ class CoreUpgrader extends \Core_Upgrader {
 			return $temp;
 		}
 	}
+
+	/**
+	 * Upgrade WordPress core.
+	 *
+	 * @access public
+	 *
+	 * @global WP_Filesystem_Base $wp_filesystem Subclass
+	 * @global callable           $_wp_filesystem_direct_method
+	 *
+	 * @param object $current Response object for whether WordPress is current.
+	 * @param array  $args {
+	 *        Optional. Arguments for upgrading WordPress core. Default empty array.
+	 *
+	 *        @type bool $pre_check_md5    Whether to check the file checksums before
+	 *                                     attempting the upgrade. Default true.
+	 *        @type bool $attempt_rollback Whether to attempt to rollback the chances if
+	 *                                     there is a problem. Default false.
+	 *        @type bool $do_rollback      Whether to perform this "upgrade" as a rollback.
+	 *                                     Default false.
+	 * }
+	 * @return null|false|WP_Error False or WP_Error on failure, null on success.
+	 */
+	public function upgrade( $current, $args = array() ) {
+		$old_error_handler = set_error_handler( array( __CLASS__, 'error_handler' ), E_USER_WARNING | E_USER_NOTICE );
+
+		$result = parent::upgrade( $current, $args );
+
+		set_error_handler( $old_error_handler );
+
+		return $result;
+	}
+
+	/**
+	 * Error handler to ignore failures on accessing SSL "https://api.wordpress.org/core/checksums/1.0/" in `get_core_checksums()` which seem to occur intermittently.
+	 */
+	static public function error_handler( int $errno, string $errstr, string $errfile, int $errline, array $errcontext = null ) {
+		// If ignoring E_USER_WARNING | E_USER_NOTICE, default.
+		if ( ! ( error_reporting() & $errno ) ) {
+			return false;
+		}
+		// If not in "wp-admin/includes/update.php", default.
+		$update_php = 'wp-admin/includes/update.php';
+		if ( 0 !== substr_compare( $errfile, $update_php, -strlen( $update_php ) ) ) {
+			return false;
+		}
+		// Else assume it's in `get_core_checksums()` and just ignore it.
+		return true;
+	}
 }

--- a/src/WP_CLI/CoreUpgrader.php
+++ b/src/WP_CLI/CoreUpgrader.php
@@ -112,11 +112,11 @@ class CoreUpgrader extends \Core_Upgrader {
 	 * @return null|false|WP_Error False or WP_Error on failure, null on success.
 	 */
 	public function upgrade( $current, $args = array() ) {
-		$old_error_handler = set_error_handler( array( __CLASS__, 'error_handler' ), E_USER_WARNING | E_USER_NOTICE );
+		set_error_handler( array( __CLASS__, 'error_handler' ), E_USER_WARNING | E_USER_NOTICE );
 
 		$result = parent::upgrade( $current, $args );
 
-		set_error_handler( $old_error_handler );
+		restore_error_handler();
 
 		return $result;
 	}


### PR DESCRIPTION
See https://github.com/wp-cli/core-command/pull/47#issuecomment-345878875 and build https://travis-ci.org/wp-cli/core-command/jobs/304982306

Ignores PHP notice triggered in WP `get_core_checksums()` when SSL access to "https://api.wordpress.org" fails.