### PR TITLE
Use proper tabs to indent docblock

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -920,9 +920,9 @@ EOT;
 	 *
 	 * [--force]
 	 * : Update even when installed WP version is greater than the requested version.
-     *
-     * [--locale=<locale>]
-     * : Select which language you want to download.
+	 *
+	 * [--locale=<locale>]
+	 * : Select which language you want to download.
 	 *
 	 * ## EXAMPLES
 	 *


### PR DESCRIPTION
Just stumbled upon this while browsing through the code.

Doesn't look like the docblock parser was affected by that, so it's purely a cosmetic change.