### PR TITLE
Change Composer setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 vendor/
 *.zip
 *.tar.gz
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {},
     "require-dev": {
         "behat/behat": "~2.5",
-        "wp-cli/wp-cli": "^1.5"
+        "wp-cli/wp-cli": "*"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
* Changes requirement for `wp-cli/wp-cli` back from `^1.5` to `*`. This is needed so people can pull intermediate versions through the package manager for testing.
* Git-ignores the Composer lock file.