### PR TITLE
Sanitize database at the end of install to prevent duplicate data

### DIFF
--- a/features/core-install.feature
+++ b/features/core-install.feature
@@ -200,3 +200,38 @@ Feature: Install WordPress core
     """
     Addition of multisite constants to 'wp-config.php' skipped. You need to add them manually:
     """
+
+  Scenario: Install WordPress multisite with existing multisite constants in wp-config file
+    Given an empty directory
+    And WP files
+    And a database
+    And a extra-config file:
+      """
+      define( 'WP_ALLOW_MULTISITE', true );
+      define( 'MULTISITE', true );
+      define( 'SUBDOMAIN_INSTALL', true );
+      $base = '/';
+      define( 'DOMAIN_CURRENT_SITE', 'foobar.org' );
+      define( 'PATH_CURRENT_SITE', '/' );
+      define( 'SITE_ID_CURRENT_SITE', 1 );
+      define( 'BLOG_ID_CURRENT_SITE', 1 );
+      """
+
+    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < extra-config`
+    Then STDOUT should be:
+      """
+      Success: Generated 'wp-config.php' file.
+      """
+
+    When I run `wp core multisite-install --url=foobar.org --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=password --skip-config`
+    Then STDOUT should be:
+      """
+      Created single site database tables.
+      Set up multisite database tables.
+      Success: Network installed. Don't forget to set up rewrite rules (and a .htaccess file, if using Apache).
+      """
+
+    When I run `wp db query "select * from wp_sitemeta where meta_key = 'site_admins' and meta_value = ''"`
+    Then STDOUT should be:
+      """
+      """

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -686,12 +686,10 @@ EOT;
 				WP_CLI::warning( "Multisite constants could not be written to 'wp-config.php'. You may need to add them manually:" . PHP_EOL . $ms_config );
 			}
 		} else {
-			/**
-			 * Multisite constants are defined, therefore we already have an empty site_admins site meta
+			/* Multisite constants are defined, therefore we already have an empty site_admins site meta.
 			 *
-			 * Code based on parts of delete_network_option
-			 */
-			$rows = $wpdb->get_results( "SELECT meta_id, site_id FROM {$wpdb->sitemeta} WHERE meta_key = 'site_admins'" );
+			 * Code based on parts of delete_network_option. */
+			$rows = $wpdb->get_results( "SELECT meta_id, site_id FROM {$wpdb->sitemeta} WHERE meta_key = 'site_admins' AND meta_value = ''" );
 
 			foreach ( $rows as $row ) {
 				$cache_key = sprintf( '%d:site_admins', $row->site_id );

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -685,6 +685,22 @@ EOT;
 			} else {
 				WP_CLI::warning( "Multisite constants could not be written to 'wp-config.php'. You may need to add them manually:" . PHP_EOL . $ms_config );
 			}
+		} else {
+			/**
+			 * Multisite constants are defined, therefore we already have an empty site_admins site meta
+			 *
+			 * Code based on parts of delete_network_option
+			 */
+			$rows = $wpdb->get_results( "SELECT meta_id, site_id FROM {$wpdb->sitemeta} WHERE meta_key = 'site_admins'" );
+
+			foreach ( $rows as $row ) {
+				$cache_key = sprintf( '%d:site_admins', $row->site_id );
+				wp_cache_delete( $cache_key, 'site-options' );
+
+				$result = $wpdb->delete( $wpdb->sitemeta, array(
+					'meta_id' => $row->meta_id,
+				) );
+			}
 		}
 
 		return true;

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -421,12 +421,14 @@ class Core_Command extends WP_CLI_Command {
 	 * @alias install-network
 	 */
 	public function multisite_convert( $args, $assoc_args ) {
-		if ( is_multisite() )
+		if ( is_multisite() ) {
 			WP_CLI::error( 'This already is a multisite install.' );
+		}
 
 		$assoc_args = self::_set_multisite_defaults( $assoc_args );
-		if ( !isset( $assoc_args['title'] ) ) {
-			$assoc_args['title'] = sprintf( _x('%s Sites', 'Default network name' ), get_option( 'blogname' ) );
+		if ( ! isset( $assoc_args['title'] ) ) {
+			// translators: placeholder is blog name
+			$assoc_args['title'] = sprintf( _x( '%s Sites', 'Default network name' ), get_option( 'blogname' ) );
 		}
 
 		if ( $this->_multisite_convert( $assoc_args ) ) {
@@ -499,7 +501,8 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		$assoc_args = self::_set_multisite_defaults( $assoc_args );
-		$assoc_args['title'] = sprintf( _x('%s Sites', 'Default network name' ), $assoc_args['title'] );
+		// translators: placeholder is user supplied title
+		$assoc_args['title'] = sprintf( _x( '%s Sites', 'Default network name' ), $assoc_args['title'] );
 
 		// Overwrite runtime args, to avoid mismatches.
 		$consts_to_args = array(
@@ -515,7 +518,7 @@ class Core_Command extends WP_CLI_Command {
 			}
 		}
 
-		if ( !$this->_multisite_convert( $assoc_args ) ) {
+		if ( ! $this->_multisite_convert( $assoc_args ) ) {
 			return;
 		}
 
@@ -624,8 +627,9 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		// need to register the multisite tables manually for some reason
-		foreach ( $wpdb->tables( 'ms_global' ) as $table => $prefixed_table )
+		foreach ( $wpdb->tables( 'ms_global' ) as $table => $prefixed_table ) {
 			$wpdb->$table = $prefixed_table;
+		}
 
 		install_network();
 
@@ -640,19 +644,19 @@ class Core_Command extends WP_CLI_Command {
 
 		if ( true === $result ) {
 			WP_CLI::log( 'Set up multisite database tables.' );
-		} else if ( is_wp_error( $result ) ) {
+		} elseif ( is_wp_error( $result ) ) {
 			switch ( $result->get_error_code() ) {
 
-			case 'siteid_exists':
-				WP_CLI::log( $result->get_error_message() );
-				return false;
+				case 'siteid_exists':
+					WP_CLI::log( $result->get_error_message() );
+					return false;
 
-			case 'no_wildcard_dns':
-				WP_CLI::warning( __( 'Wildcard DNS may not be configured correctly.' ) );
-				break;
+				case 'no_wildcard_dns':
+					WP_CLI::warning( __( 'Wildcard DNS may not be configured correctly.' ) );
+					break;
 
-			default:
-				WP_CLI::error( $result );
+				default:
+					WP_CLI::error( $result );
 			}
 		}
 
@@ -660,7 +664,7 @@ class Core_Command extends WP_CLI_Command {
 		delete_site_option( 'upload_space_check_disabled' );
 		update_site_option( 'upload_space_check_disabled', 1 );
 
-		if ( !is_multisite() ) {
+		if ( ! is_multisite() ) {
 			$subdomain_export = Utils\get_flag_value( $assoc_args, 'subdomains' ) ? 'true' : 'false';
 			$ms_config = <<<EOT
 define( 'WP_ALLOW_MULTISITE', true );


### PR DESCRIPTION
Closes #75 

If the multisite constants are already in `wp-config.php`, there's no way to stop `populate_network` to add an empty `site_admins` option when creating a new install.

This PR adds code that, at the end, would remove all empty `site_admins` options. Later `multisite-install` calls `add_site_admins` which checks whether a user is a super admin, which would fail because the option exists, but is empty, so it would add another entry to the sitemeta table.

So normally the `add_site_admins` would just update the site_admins, and that should work. Not in this case.

`update_network_option` will check the existing value of the option, and if it's `false`, then it will use `add_network_option` [because `false` means the option doesn't exist in the database](https://github.com/WordPress/WordPress/blob/master/wp-includes/option.php#L1565-L1590).

`get_network_option` will return whatever is stored in the cache. If that happens to be nothing, then the first time a query is ran, it will check in the database, and if it's not in the database, [it will store it in a `$notoptions` array, and store that in the cache](https://github.com/WordPress/WordPress/blob/master/wp-includes/option.php#L1275-L1290).

The first time `site_admins` is queried, the database is practically empty, so the `site_admins` key ends up being part of the `$notoptions` variable and cache.

Subsequent query to `get_network_option` will [hit the part where it's a `notoption` and return the default value - which is `false`](https://github.com/WordPress/WordPress/blob/master/wp-includes/option.php#L1248-L1267).

Which means in order to get this working, we need to actually delete the empty `site_admins` option, because a new one will be added anyways.