### PR TITLE
Move PHP 5.4 tests from `WP_VERSION` `latest` to `5.1`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ jobs:
     - stage: test
       php: 5.4
       dist: precise
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.1

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -273,7 +273,8 @@ Feature: Update WordPress core
       Warning: Checksums not available for WordPress {WP_VERSION-4.0-latest}/es_ES. Please cleanup files manually.
       """
     And the return code should be 0
-
+    
+  @require-php-5.6
   Scenario Outline: Use `--version=(nightly|trunk)` to update to the latest nightly version
     Given a WP install
 
@@ -293,6 +294,7 @@ Feature: Update WordPress core
     | trunk      |
     | nightly    |
 
+  @require-php-5.6
   Scenario: Installing latest nightly build should skip cache
     Given a WP install
 


### PR DESCRIPTION
Related wp-cli/wp-cli#5127