### PR TITLE
Enhancement: Add PHP 7.3 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,9 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
+      php: 7.3
+      env: WP_VERSION=latest
+    - stage: test
       php: 7.2
       env: WP_VERSION=latest
     - stage: test

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -208,6 +208,7 @@ Feature: Update WordPress core
       wordpress-4.2.4-partial-1-en_US.zip
       """
 
+  @less-than-php-7.3
   Scenario: Make sure files are cleaned up
     Given a WP install
     When I run `wp core update --version=4.4 --force`

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -242,6 +242,7 @@ Feature: Update WordPress core
     When I run `wp post create --post_title='Test post' --porcelain`
     Then STDOUT should be a number
 
+  @less-than-php-7.3
   Scenario: Minor update on an unlocalized WordPress release
     Given a WP install
     And an empty cache


### PR DESCRIPTION
This PR

* [x] adds PHP 7.3 to the Travis CI build matrix

Related to https://github.com/wp-cli/wp-cli/issues/5160.