### PR TITLE
Replace instances of `wp.dev` with `example.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ in seconds or less.
 
 Note: if you've installed WordPress in a subdirectory, then you'll need
 to `wp option update siteurl` after `wp core install`. For instance, if
-WordPress is installed in the `/wp` directory and your domain is wp.dev,
-then you'll need to run `wp option update siteurl http://wp.dev/wp` for
+WordPress is installed in the `/wp` directory and your domain is example.com,
+then you'll need to run `wp option update siteurl http://example.com/wp` for
 your WordPress installation to function properly.
 
 Note: When using custom user tables (e.g. `CUSTOM_USER_TABLE`), the admin

--- a/features/core.feature
+++ b/features/core.feature
@@ -347,7 +347,7 @@ Feature: Manage WordPress installation
 
     When I run `wp db create`
     # extra/no-mail.php not present as mu-plugin so skip sending email else will fail on Travis with "sh: 1: -t: not found"
-    And I run `wp core install --url=wp.dev --title="WP Dev" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com --skip-email`
+    And I run `wp core install --url=example.com --title="WP Example" --admin_user=wpcli --admin_password=wpcli --admin_email=wpcli@example.com --skip-email`
     Then STDOUT should contain:
       """
       Success: WordPress installed successfully.
@@ -356,13 +356,13 @@ Feature: Manage WordPress installation
     When I run `wp option get home`
     Then STDOUT should be:
       """
-      http://wp.dev
+      http://example.com
       """
 
     When I run `wp option get siteurl`
     Then STDOUT should be:
       """
-      http://wp.dev
+      http://example.com
       """
 
   Scenario: Warn when multisite constants can't be inserted into wp-config

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -339,7 +339,7 @@ class Core_Command extends WP_CLI_Command {
 	 *
 	 * Note: if you've installed WordPress in a subdirectory, then you'll need
 	 * to `wp option update siteurl` after `wp core install`. For instance, if
-	 * WordPress is installed in the `/wp` directory and your domain is wp.dev,
+	 * WordPress is installed in the `/wp` directory and your domain is example.com,
 	 * then you'll need to run `wp option update siteurl http://example.com/wp` for
 	 * your WordPress installation to function properly.
 	 *

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -340,7 +340,7 @@ class Core_Command extends WP_CLI_Command {
 	 * Note: if you've installed WordPress in a subdirectory, then you'll need
 	 * to `wp option update siteurl` after `wp core install`. For instance, if
 	 * WordPress is installed in the `/wp` directory and your domain is wp.dev,
-	 * then you'll need to run `wp option update siteurl http://wp.dev/wp` for
+	 * then you'll need to run `wp option update siteurl http://example.com/wp` for
 	 * your WordPress installation to function properly.
 	 *
 	 * Note: When using custom user tables (e.g. `CUSTOM_USER_TABLE`), the admin


### PR DESCRIPTION
Fixes #112. 

Further to PR #114, I have replaced additional instances of `wp.dev` with `example.com`. There are still additional instances [(1)](https://github.com/wp-cli/core-command/blob/master/features/core.feature#L359) and [(2)](https://github.com/wp-cli/core-command/blob/master/features/core.feature#L365), however I am not familiar with this file type and have therefore not modified it.