### PR TITLE
Fixes #118: On multisite-convert, don't assume site_id is 1

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -694,7 +694,7 @@ define( 'SUBDOMAIN_INSTALL', {$subdomain_export} );
 \$base = '{$assoc_args['base']}';
 define( 'DOMAIN_CURRENT_SITE', '{$domain}' );
 define( 'PATH_CURRENT_SITE', '{$assoc_args['base']}' );
-define( 'SITE_ID_CURRENT_SITE', '{$site_id}' );
+define( 'SITE_ID_CURRENT_SITE', $site_id );
 define( 'BLOG_ID_CURRENT_SITE', 1 );
 EOT;
 

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -694,7 +694,7 @@ define( 'SUBDOMAIN_INSTALL', {$subdomain_export} );
 \$base = '{$assoc_args['base']}';
 define( 'DOMAIN_CURRENT_SITE', '{$domain}' );
 define( 'PATH_CURRENT_SITE', '{$assoc_args['base']}' );
-define( 'SITE_ID_CURRENT_SITE', $site_id );
+define( 'SITE_ID_CURRENT_SITE', {$site_id} );
 define( 'BLOG_ID_CURRENT_SITE', 1 );
 EOT;
 

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -660,6 +660,8 @@ class Core_Command extends WP_CLI_Command {
 			$assoc_args['subdomains']
 		);
 
+		$site_id = $wpdb->get_var("SELECT id FROM $wpdb->site");
+
 		if ( true === $result ) {
 			WP_CLI::log( 'Set up multisite database tables.' );
 		} elseif ( is_wp_error( $result ) ) {
@@ -691,7 +693,7 @@ define( 'SUBDOMAIN_INSTALL', {$subdomain_export} );
 \$base = '{$assoc_args['base']}';
 define( 'DOMAIN_CURRENT_SITE', '{$domain}' );
 define( 'PATH_CURRENT_SITE', '{$assoc_args['base']}' );
-define( 'SITE_ID_CURRENT_SITE', 1 );
+define( 'SITE_ID_CURRENT_SITE', '{$site_id}' );
 define( 'BLOG_ID_CURRENT_SITE', 1 );
 EOT;
 

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -660,7 +660,8 @@ class Core_Command extends WP_CLI_Command {
 			$assoc_args['subdomains']
 		);
 
-		$site_id = $wpdb->get_var("SELECT id FROM $wpdb->site");
+		$site_id = $wpdb->get_var( "SELECT id FROM $wpdb->site" );
+		$site_id = ( null === $site_id ) ? 1 : (int) $site_id;
 
 		if ( true === $result ) {
 			WP_CLI::log( 'Set up multisite database tables.' );


### PR DESCRIPTION
In the `populate_network` function, which is used by `core multisite-convert`, I observe the following code (line 1007 of `wp-admin/includes/schema.php` at v4.9.9):

```
if ( 1 == $network_id ) {
	$wpdb->insert( $wpdb->site, array( 'domain' => $domain, 'path' => $path ) );
	$network_id = $wpdb->insert_id;
} else {
	$wpdb->insert( $wpdb->site, array( 'domain' => $domain, 'path' => $path, 'id' => $network_id ) );
}
```

My understanding of the code in `Core_Command.php` is that `multisite-convert` is invoking `populate_network()`, and passing `1` as the site id (`$network_id`). As you can see, the WP core code then sets the network_id equal to the result of the INSERT query against wp_site. In most cases, this would be 1; however, if one has configured auto_increment_increment -- as is standard practice for database clusters -- then the `wp_site` table will store the site as id 4, and the code will generate the rest of the data using that same id.

From the perspective of `core-command`, this is mostly not a concern. However, it does appear that the constant `SITE_ID_CURRENT_SITE` is hardcoded with value 1. This produces an inconsistency between the config file and the database which is less than ideal. The solution is simple -- store the actual site_id/network_id and use that instead of a hardcoded 1. The only downside is that it means one extra database query (functions like `get_main_network_id()` appear to be accessing some kind of cache, or perhaps are falling back to default, and only return 1).