### PR TITLE
Use proper function name in update-db command

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1216,7 +1216,7 @@ EOT;
 		} else {
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Replacing WP Core behavior is the goal here.
-			$wp_current_db_version = (int) __get_option( 'db_version' );
+			$wp_current_db_version = (int) get_option( 'db_version' );
 			if ( $wp_db_version !== $wp_current_db_version ) {
 				if ( $dry_run ) {
 					WP_CLI::success( "WordPress database will be upgraded from db version {$wp_current_db_version} to {$wp_db_version}." );


### PR DESCRIPTION
This PR is fixing following error
```
Fatal error: Uncaught Error: Call to undefined function __get_option() in phar:///PATH/public_html/wp-cli.phar/vendor/wp-cli/core-command/src/Core_Command.php:1219
Stack trace:
#0 [internal function]: Core_Command->update_db(Array, Array)
#1 phar:///PATH/public_html/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(98): call_user_func(Array, Array, Array)
#2 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#3 phar:///PATH/public_html/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(451): call_user_func(Object(Closure), Array, Array)
#4 phar:///PATH/public_html/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(371): WP_CLI\Dispatcher\Subcommand->invoke(Array, Array, Array)
#5 phar:///PATH in phar:///PATH/public_html/wp-cli.phar/vendor/wp-cli/core-command/src/Core_Command.php on line 1219
```
For same reason this error was not catch by test.
