### PR TITLE
Switch framework to dev-master to fix PHP notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "composer/semver": "^1.4",
-        "wp-cli/wp-cli": "^2.2"
+        "wp-cli/wp-cli": "dev-master"
     },
     "require-dev": {
         "wp-cli/checksum-command": "^1 || ^2",


### PR DESCRIPTION
This adds the fix in https://github.com/wp-cli/wp-cli/pull/5283 to get rid of a PHP notice.