### PR TITLE
Support `wp core download https://somesite/build.zip`

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -66,7 +66,7 @@ Feature: Download WordPress
     Given an empty directory
     And an empty cache
 
-    When I run `wp core download --version=https://wordpress.org/wordpress-4.9.12.zip`
+    When I run `wp core download https://wordpress.org/wordpress-4.9.12.zip`
     Then the wp-settings.php file should exist
     And the {SUITE_CACHE_DIR}/core directory should not exist
     And STDOUT should contain:

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -62,6 +62,20 @@ Feature: Download WordPress
       """
     And the return code should be 1
 
+  Scenario: Core download from a URL
+    Given an empty directory
+    And an empty cache
+
+    When I run `wp core download --version=https://wordpress.org/wordpress-4.9.12.zip`
+    Then the wp-settings.php file should exist
+    And the {SUITE_CACHE_DIR}/core directory should not exist
+    And STDOUT should contain:
+      """
+      Downloading from https://wordpress.org/wordpress-4.9.12.zip ...
+      md5 hash verified: 702c94bc3aa8a37091f9fb075d57d847
+      Success: WordPress downloaded.
+      """
+
   Scenario: Verify release hash when downloading new version
     Given an empty directory
     And an empty cache

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -155,7 +155,9 @@ class Core_Command extends WP_CLI_Command {
 
 		$locale       = Utils\get_flag_value( $assoc_args, 'locale', 'en_US' );
 		$skip_content = Utils\get_flag_value( $assoc_args, 'skip-content' );
-		$from_url     = false;
+
+		list( $download_url ) = $args;
+		$from_url             = ! empty( $download_url );
 
 		if ( ! empty( $args[0] ) ) {
 			// URL is given

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -104,6 +104,9 @@ class Core_Command extends WP_CLI_Command {
 	 * [--locale=<locale>]
 	 * : Select which language you want to download.
 	 *
+	 * [<download-url>]
+	 * : Download directly from a provided URL instead of fetching the URL from the wordpress.org servers.
+	 *
 	 * [--version=<version>]
 	 * : Select which version you want to download. Accepts a version number, 'latest' or 'nightly', or a URL.
 	 *

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -160,7 +160,7 @@ class Core_Command extends WP_CLI_Command {
 		$from_url             = ! empty( $download_url );
 
 		if ( $from_url ) {
-			$version      = null;
+			$version = null;
 			if ( isset( $assoc_args['version'] ) ) {
 				WP_CLI::error( 'Version option is not available for URL downloads.' );
 			}

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -156,8 +156,8 @@ class Core_Command extends WP_CLI_Command {
 		$locale       = Utils\get_flag_value( $assoc_args, 'locale', 'en_US' );
 		$skip_content = Utils\get_flag_value( $assoc_args, 'skip-content' );
 
-		list( $download_url ) = $args;
-		$from_url             = ! empty( $download_url );
+		$download_url = array_shift( $args );
+		$from_url     = ! empty( $download_url );
 
 		if ( $from_url ) {
 			$version = null;

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -211,7 +211,7 @@ class Core_Command extends WP_CLI_Command {
 		if ( $skip_content && 'zip' !== $extension ) {
 			WP_CLI::error( 'Skip content is only available for ZIP files.' );
 		}
-		if ( ( $skip_content || $locale !== 'en_US' ) && ! $version ) {
+		if ( ( $skip_content || 'en_US' !== $locale ) && ! $version ) {
 			WP_CLI::error( 'Skip content and locale options are not available for URL downloads.' );
 		}
 

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -162,6 +162,9 @@ class Core_Command extends WP_CLI_Command {
 			$version      = null;
 			$from_url     = true;
 			$download_url = $args[0];
+			if ( isset( $assoc_args['version'] ) ) {
+				WP_CLI::error( 'Version option is not available for URL downloads.' );
+			}
 			if ( $skip_content || 'en_US' !== $locale ) {
 				WP_CLI::error( 'Skip content and locale options are not available for URL downloads.' );
 			}

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -268,7 +268,7 @@ class Core_Command extends WP_CLI_Command {
 
 			if ( 'nightly' !== $version ) {
 				$md5_response = Utils\http_request( 'GET', $download_url . '.md5' );
-				if ( 200 === $md5_response->status_code ) {
+				if ( $md5_response->status_code >= 200 && $md5_response->status_code < 300 ) {
 					$md5_file = md5_file( $temp );
 
 					if ( $md5_file === $md5_response->body ) {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -161,7 +161,6 @@ class Core_Command extends WP_CLI_Command {
 
 		if ( $from_url ) {
 			$version      = null;
-			$from_url     = true;
 			$download_url = $args[0];
 			if ( isset( $assoc_args['version'] ) ) {
 				WP_CLI::error( 'Version option is not available for URL downloads.' );

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -160,7 +160,6 @@ class Core_Command extends WP_CLI_Command {
 		$from_url             = ! empty( $download_url );
 
 		if ( $from_url ) {
-			// URL is given
 			$version      = null;
 			$from_url     = true;
 			$download_url = $args[0];

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -161,7 +161,6 @@ class Core_Command extends WP_CLI_Command {
 
 		if ( $from_url ) {
 			$version      = null;
-			$download_url = $args[0];
 			if ( isset( $assoc_args['version'] ) ) {
 				WP_CLI::error( 'Version option is not available for URL downloads.' );
 			}

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -159,7 +159,7 @@ class Core_Command extends WP_CLI_Command {
 		list( $download_url ) = $args;
 		$from_url             = ! empty( $download_url );
 
-		if ( ! empty( $args[0] ) ) {
+		if ( $from_url ) {
 			// URL is given
 			$version      = null;
 			$from_url     = true;

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -168,7 +168,6 @@ class Core_Command extends WP_CLI_Command {
 			if ( $skip_content || 'en_US' !== $locale ) {
 				WP_CLI::error( 'Skip content and locale options are not available for URL downloads.' );
 			}
-
 		} elseif ( isset( $assoc_args['version'] ) && 'latest' !== $assoc_args['version'] ) {
 			$version = $assoc_args['version'];
 			if ( in_array( strtolower( $version ), [ 'trunk', 'nightly' ], true ) ) {


### PR DESCRIPTION
Closes #131.

This change also makes a failure to retrieve the MD5 checksum into a warning rather than an error, and fixes a related minor bug along the way:

```diff
- WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$response->status_code})." );
+ WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$md5_response->status_code})." );
```

Previously this printed `Couldn't access md5 hash for release (HTTP code 200)` using the response code from the zip download.

It'll be slightly easier to review this diff ignoring whitespace changes: https://github.com/wp-cli/core-command/pull/135/files?w=1