### PR TITLE
Fix the build

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -340,7 +340,7 @@ Feature: Download WordPress
   Scenario: Core download without the wp-content dir should work non US locale
     Given an empty directory
 
-    When I run `wp core download --skip-content --locale=nl_NL`
+    When I run `wp core download --skip-content --version=4.9.11 --locale=nl_NL`
     Then STDOUT should contain:
       """
       Success: WordPress downloaded.


### PR DESCRIPTION
The build is currently failing because the set of WP versions released today don't have locale-specific builds yet ([full log](https://travis-ci.org/wp-cli/core-command/jobs/597965445)):

![2019-10-15T04-40-55Z](https://user-images.githubusercontent.com/227022/66801017-148b6500-ef07-11e9-8b86-cf21704a3631.png)

All other tests that use `--locale=` specify a known-good WP version, this PR updates the failing test to do the same.