### PR TITLE
Remove command substitution from is-installed

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -348,7 +348,7 @@ class Core_Command extends WP_CLI_Command {
 	 *     1
 	 *
 	 *     # Bash script for checking whether WordPress is installed or not
-	 *     if ! $(wp core is-installed); then
+	 *     if ! wp core is-installed; then
 	 *         wp core install
 	 *     fi
 	 *


### PR DESCRIPTION
Remove the `$(...)` from the example for #144 