### PR TITLE
Remove only themes/plugins folders from archive.

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1411,7 +1411,7 @@ EOT;
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			for ( $i = 0; $i < $zip->numFiles; $i++ ) {
 				$info = $zip->statIndex( $i );
-				if ( false !== stripos( $info['name'], 'wp-content/' ) ) {
+				if ( false !== stripos( $info['name'], 'themes/' ) || false !== stripos( $info['name'], 'plugins/' ) ) {
 					$zip->deleteIndex( $i );
 				}
 			}


### PR DESCRIPTION
Pull request #59 strips the whole `wp-content` directory, removing `languages` directory too and raising the issue that `--locale=` flag is broken. Closes #147.

I just changed the if-statement to strip out `plugins` and `themes` separately.

No idea how to write tests for that, it is a fairly simple fix.