### PR TITLE
Fix DB Upgrade tests for PHP 7.4

### DIFF
--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -2,8 +2,8 @@ Feature: Update core's database
 
   Scenario: Update db on a single site
     Given a WP install
-    And I run `wp core download --version=4.1 --force`
-    And I run `wp option update db_version 29630`
+    And I run `wp core download --version=5.4 --force`
+    And I run `wp option update db_version 45805`
 
     When I run `wp core update-db`
     Then STDOUT should contain:
@@ -19,8 +19,8 @@ Feature: Update core's database
 
   Scenario: Dry run update db on a single site
     Given a WP install
-    And I run `wp core download --version=4.1 --force`
-    And I run `wp option update db_version 29630`
+    And I run `wp core download --version=5.4 --force`
+    And I run `wp option update db_version 45805`
 
     When I run `wp core update-db --dry-run`
     Then STDOUT should be:
@@ -37,9 +37,9 @@ Feature: Update core's database
 
   Scenario: Update db across network
     Given a WP multisite install
-    And I run `wp core download --version=4.1 --force`
-    And I run `wp option update db_version 29630`
-    And I run `wp site option update wpmu_upgrade_site 29630`
+    And I run `wp core download --version=5.4 --force`
+    And I run `wp option update db_version 45805`
+    And I run `wp site option update wpmu_upgrade_site 45805`
     And I run `wp site create --slug=foo`
     And I run `wp site create --slug=bar`
     And I run `wp site create --slug=burrito --porcelain`
@@ -69,9 +69,9 @@ Feature: Update core's database
 
   Scenario: Update db across network, dry run
     Given a WP multisite install
-    And I run `wp core download --version=4.1 --force`
-    And I run `wp option update db_version 29630`
-    And I run `wp site option update wpmu_upgrade_site 29630`
+    And I run `wp core download --version=5.4 --force`
+    And I run `wp option update db_version 45805`
+    And I run `wp site option update wpmu_upgrade_site 45805`
     And I run `wp site create --slug=foo`
     And I run `wp site create --slug=bar`
     And I run `wp site create --slug=burrito --porcelain`

--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -8,13 +8,13 @@ Feature: Update core's database
     When I run `wp core update-db`
     Then STDOUT should contain:
       """
-      Success: WordPress database upgraded successfully from db version 29630 to 30133.
+      Success: WordPress database upgraded successfully from db version 45805 to 47018.
       """
 
     When I run `wp core update-db`
     Then STDOUT should contain:
       """
-      Success: WordPress database already at latest db version 30133.
+      Success: WordPress database already at latest db version 47018.
       """
 
   Scenario: Dry run update db on a single site
@@ -26,7 +26,7 @@ Feature: Update core's database
     Then STDOUT should be:
       """
       Performing a dry run, with no database modification.
-      Success: WordPress database will be upgraded from db version 29630 to 30133.
+      Success: WordPress database will be upgraded from db version 45805 to 47018.
       """
 
     When I run `wp option get db_version`

--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -32,7 +32,7 @@ Feature: Update core's database
     When I run `wp option get db_version`
     Then STDOUT should be:
       """
-      29630
+      45805
       """
 
   Scenario: Update db across network


### PR DESCRIPTION
The notices on PHP 7.4 were caused by the fact that we pulled in WP 4.1 for testing the DB upgrade procedure, and 4.1 is not fully compatible with PHP 7.4, of course.