### PR TITLE
Fix WP < 5.5 compatibility due to incompatible method signatures.

### DIFF
--- a/src/WP_CLI/Core/Compat/DownloadPackageMethodTrait.php
+++ b/src/WP_CLI/Core/Compat/DownloadPackageMethodTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WP_CLI\Core\Compat;
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound,Generic.Classes.DuplicateClassName.Found
+
+if ( \WP_CLI\Utils\wp_version_compare( '5.5-alpha-48399', '>=' ) ) {
+
+	require_once __DIR__ . '/Min_WP_5_5/DownloadPackageMethodTrait.php';
+
+	trait DownloadPackageMethodTrait {
+
+		use Min_WP_5_5\DownloadPackageMethodTrait;
+	}
+
+	return;
+}
+
+require_once __DIR__ . '/Min_WP_3_7/DownloadPackageMethodTrait.php';
+
+trait DownloadPackageMethodTrait {
+
+	use Min_WP_3_7\DownloadPackageMethodTrait;
+}

--- a/src/WP_CLI/Core/Compat/Min_WP_3_7/DownloadPackageMethodTrait.php
+++ b/src/WP_CLI/Core/Compat/Min_WP_3_7/DownloadPackageMethodTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace WP_CLI\Core\Compat\Min_WP_3_7;
+
+trait DownloadPackageMethodTrait {
+
+	/**
+	 * Compatibility method for signature changes to {@see \WP_Upgrader::download_package()}
+	 *
+	 * @param string $package          The URI of the package. If this is the full path to an
+	 *                                 existing local file, it will be returned untouched.
+	 * @param bool   $check_signatures Whether to validate file signatures. Default true.
+	 * @return string|\WP_Error The full path to the downloaded package file, or a WP_Error object.
+	 */
+	public function download( $package, $check_signatures = true ) {
+		return $this->process_download_package( $package, $check_signatures, [] );
+	}
+}

--- a/src/WP_CLI/Core/Compat/Min_WP_5_5/DownloadPackageMethodTrait.php
+++ b/src/WP_CLI/Core/Compat/Min_WP_5_5/DownloadPackageMethodTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace WP_CLI\Core\Compat\Min_WP_5_5;
+
+trait DownloadPackageMethodTrait {
+
+	/**
+	 * Compatibility method for signature changes to {@see \WP_Upgrader::download_package()}
+	 *
+	 * @param string $package          The URI of the package. If this is the full path to an
+	 *                                 existing local file, it will be returned untouched.
+	 * @param bool   $check_signatures Whether to validate file signatures. Default true.
+	 * @param array  $hook_extra       Extra arguments to pass to the filter hooks. Default empty array.
+	 * @return string|\WP_Error The full path to the downloaded package file, or a WP_Error object.
+	 */
+	public function download( $package, $check_signatures = true, $hook_extra = [] ) {
+		return $this->process_download_package( $package, $check_signatures, $hook_extra );
+	}
+}

--- a/src/WP_CLI/Core/CoreUpgrader.php
+++ b/src/WP_CLI/Core/CoreUpgrader.php
@@ -17,6 +17,8 @@ use WP_Filesystem_Base;
  */
 class CoreUpgrader extends DefaultCoreUpgrader {
 
+	use WP_CLI\Core\Compat\DownloadPackageMethodTrait;
+
 	/**
 	 * Caches the download, and uses cached if available.
 	 *
@@ -28,7 +30,7 @@ class CoreUpgrader extends DefaultCoreUpgrader {
 	 * @param array  $hook_extra       Extra arguments to pass to the filter hooks. Default empty array.
 	 * @return string|WP_Error The full path to the downloaded package file, or a WP_Error object.
 	 */
-	public function download_package( $package, $check_signatures = true, $hook_extra = [] ) {
+	private function process_download_package( $package, $check_signatures = true, $hook_extra = [] ) {
 
 		/**
 		 * Filter whether to return the package.


### PR DESCRIPTION
WordPress 5.5 added a new parameter to `WP_Upgrader::download_package()`. WP-CLI
subclasses the `Core_Upgrader` class to customize this behavior. This causes a
PHP warning on 7.4 and fatal error on 8.0 if the method signatures do not match.

In #166 the method signature was adjusted to account for this new parameter,
however this causes the same incompatible signature issue on sites running WP
versions before 5.5.

This commit introduces a trait-based compatibility shim to use the correct method
signature depending on the WP version being run. This is patterned off the
implementation used in the `FeedbackMethodTrait`.

I tested this manually by running the following commands on PHP 8.

```sh
./bin/wp core update --version=5.4 --force
./bin/wp core version
./bin/wp core update --version=5.5 --force
./bin/wp core version
./bin/wp core update --version=nightly --force
./bin/wp core version
```
