### PR TITLE
Do not exit on error but pass on error

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1213,7 +1213,10 @@ EOT;
 				if ( $dry_run ) {
 					$cmd .= ' --dry-run';
 				}
-				$process = WP_CLI::runcommand( $cmd, [ 'return' => 'all' ] );
+				$process = WP_CLI::runcommand( $cmd, [
+					'return' => 'all',
+					'exit_error' => false,
+				] );
 				if ( 0 === (int) $process->return_code ) {
 					// See if we can parse the stdout
 					if ( preg_match( '#Success: (.+)#', $process->stdout, $matches ) ) {


### PR DESCRIPTION
When running `wp core update-db --network` it was failing without any message.  When running this command with the change, it looks as follows.

```
$ wp core update-db --network
Warning: Database failed to upgrade on example.required.test/
Warning: Database failed to upgrade on beispiel.required.test/
Success: WordPress database upgraded on 0/2 sites.
```