### PR TITLE
Update `download_package()` function signature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wp-cli/db-command": "^1.3 || ^2",
         "wp-cli/entity-command": "^1.3 || ^2",
         "wp-cli/extension-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^3.1"
+        "wp-cli/wp-cli-tests": "^3.1.4"
     },
     "config": {
         "process-timeout": 7200,

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "composer/semver": "^1.4 || ^2 || ^3",
-        "wp-cli/wp-cli": "^2.5"
+        "wp-cli/wp-cli": "^2.5.1"
     },
     "require-dev": {
         "wp-cli/checksum-command": "^1 || ^2",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wp-cli/db-command": "^1.3 || ^2",
         "wp-cli/entity-command": "^1.3 || ^2",
         "wp-cli/extension-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^3.0.11"
+        "wp-cli/wp-cli-tests": "^3.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,10 @@
     },
     "config": {
         "process-timeout": 7200,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -2,6 +2,7 @@ Feature: Check for more recent versions
 
   Scenario: Check for update via Version Check API
     Given a WP install
+    And I try `wp theme install twentytwenty --activate`
 
     When I run `wp core download --version=4.4 --force`
     Then STDOUT should not be empty
@@ -42,6 +43,7 @@ Feature: Check for more recent versions
 
   Scenario: No minor updates for an unlocalized WordPress release
     Given a WP install
+    And I try `wp theme install twentytwenty --activate`
 
     # If current WP_VERSION is nightly, trunk or old then from checksums might not exist, so STDERR may or may not be empty.
     When I try `wp core download --version=4.0 --locale=es_ES --force`

--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -44,7 +44,7 @@ Feature: Update core's database
         remove_action( 'after_switch_theme', '_wp_sidebars_changed' );
       } );
       """
-    And I run `wp theme activate twentytwenty`
+    And I try `wp theme install twentytwenty --activate`
     And I run `wp core download --version=5.4 --force`
     And I run `wp option update db_version 45805 --require=disable_sidebar_check.php`
     And I run `wp site option update wpmu_upgrade_site 45805`
@@ -84,7 +84,7 @@ Feature: Update core's database
         remove_action( 'after_switch_theme', '_wp_sidebars_changed' );
       } );
       """
-    And I run `wp theme activate twentytwenty`
+    And I try `wp theme install twentytwenty --activate`
     And I run `wp core download --version=5.4 --force`
     And I run `wp option update db_version 45805 --require=disable_sidebar_check.php`
     And I run `wp site option update wpmu_upgrade_site 45805`

--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -2,6 +2,7 @@ Feature: Update core's database
 
   Scenario: Update db on a single site
     Given a WP install
+    And I try `wp theme install twentytwenty --activate`
     And I run `wp core download --version=5.4 --force`
     And I run `wp option update db_version 45805`
 
@@ -19,6 +20,7 @@ Feature: Update core's database
 
   Scenario: Dry run update db on a single site
     Given a WP install
+    And I try `wp theme install twentytwenty --activate`
     And I run `wp core download --version=5.4 --force`
     And I run `wp option update db_version 45805`
 

--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -37,9 +37,16 @@ Feature: Update core's database
 
   Scenario: Update db across network
     Given a WP multisite install
+    And a disable_sidebar_check.php file:
+      """
+      <?php
+      WP_CLI::add_wp_hook( 'init', static function () {
+        remove_action( 'after_switch_theme', '_wp_sidebars_changed' );
+      } );
+      """
     And I run `wp theme activate twentytwenty`
     And I run `wp core download --version=5.4 --force`
-    And I run `wp option update db_version 45805`
+    And I run `wp option update db_version 45805 --require=disable_sidebar_check.php`
     And I run `wp site option update wpmu_upgrade_site 45805`
     And I run `wp site create --slug=foo`
     And I run `wp site create --slug=bar`
@@ -70,9 +77,16 @@ Feature: Update core's database
 
   Scenario: Update db across network, dry run
     Given a WP multisite install
+    And a disable_sidebar_check.php file:
+      """
+      <?php
+      WP_CLI::add_wp_hook( 'init', static function () {
+        remove_action( 'after_switch_theme', '_wp_sidebars_changed' );
+      } );
+      """
     And I run `wp theme activate twentytwenty`
     And I run `wp core download --version=5.4 --force`
-    And I run `wp option update db_version 45805`
+    And I run `wp option update db_version 45805 --require=disable_sidebar_check.php`
     And I run `wp site option update wpmu_upgrade_site 45805`
     And I run `wp site create --slug=foo`
     And I run `wp site create --slug=bar`

--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -37,6 +37,7 @@ Feature: Update core's database
 
   Scenario: Update db across network
     Given a WP multisite install
+    And I run `wp theme activate twentytwenty`
     And I run `wp core download --version=5.4 --force`
     And I run `wp option update db_version 45805`
     And I run `wp site option update wpmu_upgrade_site 45805`
@@ -69,6 +70,7 @@ Feature: Update core's database
 
   Scenario: Update db across network, dry run
     Given a WP multisite install
+    And I run `wp theme activate twentytwenty`
     And I run `wp core download --version=5.4 --force`
     And I run `wp option update db_version 45805`
     And I run `wp site option update wpmu_upgrade_site 45805`

--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -2,9 +2,16 @@ Feature: Update core's database
 
   Scenario: Update db on a single site
     Given a WP install
+    And a disable_sidebar_check.php file:
+      """
+      <?php
+      WP_CLI::add_wp_hook( 'init', static function () {
+        remove_action( 'after_switch_theme', '_wp_sidebars_changed' );
+      } );
+      """
     And I try `wp theme install twentytwenty --activate`
     And I run `wp core download --version=5.4 --force`
-    And I run `wp option update db_version 45805`
+    And I run `wp option update db_version 45805 --require=disable_sidebar_check.php`
 
     When I run `wp core update-db`
     Then STDOUT should contain:
@@ -20,9 +27,16 @@ Feature: Update core's database
 
   Scenario: Dry run update db on a single site
     Given a WP install
+    And a disable_sidebar_check.php file:
+      """
+      <?php
+      WP_CLI::add_wp_hook( 'init', static function () {
+        remove_action( 'after_switch_theme', '_wp_sidebars_changed' );
+      } );
+      """
     And I try `wp theme install twentytwenty --activate`
     And I run `wp core download --version=5.4 --force`
-    And I run `wp option update db_version 45805`
+    And I run `wp option update db_version 45805 --require=disable_sidebar_check.php`
 
     When I run `wp core update-db --dry-run`
     Then STDOUT should be:

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -64,6 +64,7 @@ Feature: Update WordPress core
 
   Scenario: Update to the latest minor release (PHP 7.1 compatible with WP >= 3.9)
     Given a WP install
+    And I try `wp theme install twentytwenty --activate`
 
     When I run `wp core download --version=3.9.9 --force`
     Then STDOUT should not be empty

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -2,6 +2,7 @@ Feature: Update WordPress core
 
   Scenario: Update from a ZIP file
     Given a WP install
+    And I run `wp theme activate twentytwenty`
 
     When I run `wp core download --version=3.9 --force`
     Then STDOUT should not be empty
@@ -97,6 +98,7 @@ Feature: Update WordPress core
 
   Scenario: Core update from cache
     Given a WP install
+    And I run `wp theme activate twentytwenty`
     And an empty cache
 
     When I run `wp core update --version=3.9.1 --force`
@@ -145,6 +147,7 @@ Feature: Update WordPress core
 
   Scenario: Ensure cached partial upgrades aren't used in full upgrade
     Given a WP install
+    And I run `wp theme activate twentytwenty`
     And an empty cache
     And a wp-content/mu-plugins/upgrade-override.php file:
       """
@@ -248,6 +251,7 @@ Feature: Update WordPress core
   @less-than-php-7.3
   Scenario: Minor update on an unlocalized WordPress release
     Given a WP install
+    And I run `wp theme activate twentytwenty`
     And an empty cache
 
     # If current WP_VERSION is nightly, trunk or old then from checksums might not exist, so STDERR may or may not be empty.

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -213,6 +213,7 @@ Feature: Update WordPress core
   @less-than-php-7.3
   Scenario: Make sure files are cleaned up
     Given a WP install
+    And I run `wp theme activate twentytwenty`
     When I run `wp core update --version=4.4 --force`
     Then the wp-includes/rest-api.php file should exist
     Then the wp-includes/class-wp-comment.php file should exist

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -35,6 +35,7 @@ Feature: Update WordPress core
   @less-than-php-7
   Scenario: Update to the latest minor release
     Given a WP install
+    And I try `wp theme install twentytwenty --activate`
 
     When I run `wp core download --version=3.7.9 --force`
     Then STDOUT should not be empty

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -2,7 +2,7 @@ Feature: Update WordPress core
 
   Scenario: Update from a ZIP file
     Given a WP install
-    And I run `wp theme activate twentytwenty`
+    And I try `wp theme install twentytwenty --activate`
 
     When I run `wp core download --version=3.9 --force`
     Then STDOUT should not be empty
@@ -98,7 +98,7 @@ Feature: Update WordPress core
 
   Scenario: Core update from cache
     Given a WP install
-    And I run `wp theme activate twentytwenty`
+    And I try `wp theme install twentytwenty --activate`
     And an empty cache
 
     When I run `wp core update --version=3.9.1 --force`
@@ -147,7 +147,7 @@ Feature: Update WordPress core
 
   Scenario: Ensure cached partial upgrades aren't used in full upgrade
     Given a WP install
-    And I run `wp theme activate twentytwenty`
+    And I try `wp theme install twentytwenty --activate`
     And an empty cache
     And a wp-content/mu-plugins/upgrade-override.php file:
       """
@@ -216,7 +216,7 @@ Feature: Update WordPress core
   @less-than-php-7.3
   Scenario: Make sure files are cleaned up
     Given a WP install
-    And I run `wp theme activate twentytwenty`
+    And I try `wp theme install twentytwenty --activate`
     When I run `wp core update --version=4.4 --force`
     Then the wp-includes/rest-api.php file should exist
     Then the wp-includes/class-wp-comment.php file should exist
@@ -251,7 +251,7 @@ Feature: Update WordPress core
   @less-than-php-7.3
   Scenario: Minor update on an unlocalized WordPress release
     Given a WP install
-    And I run `wp theme activate twentytwenty`
+    And I try `wp theme install twentytwenty --activate`
     And an empty cache
 
     # If current WP_VERSION is nightly, trunk or old then from checksums might not exist, so STDERR may or may not be empty.

--- a/features/core.feature
+++ b/features/core.feature
@@ -63,7 +63,7 @@ Feature: Manage WordPress installation
     When I run `wp eval 'echo home_url();'`
     Then STDOUT should be:
       """
-      http://localhost:8001
+      https://localhost:8001
       """
 
   Scenario: Install WordPress by prompting for the admin email and password

--- a/features/core.feature
+++ b/features/core.feature
@@ -212,13 +212,6 @@ Feature: Manage WordPress installation
 
   Scenario: Install multisite from scratch, with MULTISITE already set in wp-config.php
     Given a WP multisite install
-    And a disable_default_scripts.php file:
-      """
-      <?php
-      WP_CLI::add_wp_hook( 'init', static function () {
-        remove_action( 'wp_default_scripts', 'wp_default_scripts' );
-      } );
-      """
     And I run `wp db reset --yes`
 
     When I try `wp core is-installed`
@@ -229,7 +222,7 @@ Feature: Manage WordPress installation
       WordPress database error Table
       """
 
-    When I run `wp core multisite-install --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1 --require=disable_default_scripts.php`
+    When I run `wp core multisite-install --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1`
     Then STDOUT should not be empty
 
     When I run `wp eval 'echo $GLOBALS["current_site"]->domain;'`

--- a/features/core.feature
+++ b/features/core.feature
@@ -212,6 +212,13 @@ Feature: Manage WordPress installation
 
   Scenario: Install multisite from scratch, with MULTISITE already set in wp-config.php
     Given a WP multisite install
+    And a disable_default_scripts.php file:
+      """
+      <?php
+      WP_CLI::add_wp_hook( 'init', static function () {
+        remove_action( 'wp_default_scripts', 'wp_default_scripts' );
+      } );
+      """
     And I run `wp db reset --yes`
 
     When I try `wp core is-installed`
@@ -222,7 +229,7 @@ Feature: Manage WordPress installation
       WordPress database error Table
       """
 
-    When I run `wp core multisite-install --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1`
+    When I run `wp core multisite-install --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1 --require=disable_default_scripts.php`
     Then STDOUT should not be empty
 
     When I run `wp eval 'echo $GLOBALS["current_site"]->domain;'`

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1213,10 +1213,13 @@ EOT;
 				if ( $dry_run ) {
 					$cmd .= ' --dry-run';
 				}
-				$process = WP_CLI::runcommand( $cmd, [
-					'return' => 'all',
-					'exit_error' => false,
-				] );
+				$process = WP_CLI::runcommand(
+					$cmd,
+					[
+						'return'     => 'all',
+						'exit_error' => false,
+					]
+				);
 				if ( 0 === (int) $process->return_code ) {
 					// See if we can parse the stdout
 					if ( preg_match( '#Success: (.+)#', $process->stdout, $matches ) ) {

--- a/src/WP_CLI/Core/CoreUpgrader.php
+++ b/src/WP_CLI/Core/CoreUpgrader.php
@@ -41,11 +41,11 @@ class CoreUpgrader extends DefaultCoreUpgrader {
 	 *
 	 * @param string $package          The URI of the package. If this is the full path to an
 	 *                                 existing local file, it will be returned untouched.
-	 * @param bool   $check_signatures Whether to validate file signatures. Default true.
+	 * @param bool   $check_signatures Whether to validate file signatures. Default false.
 	 * @param array  $hook_extra       Extra arguments to pass to the filter hooks. Default empty array.
 	 * @return string|WP_Error The full path to the downloaded package file, or a WP_Error object.
 	 */
-	public function download_package( $package, $check_signatures = true, $hook_extra = [] ) {
+	public function download_package( $package, $check_signatures = false, $hook_extra = [] ) {
 
 		/**
 		 * Filter whether to return the package.


### PR DESCRIPTION
Synchronise function signature with WordPress core.
