### PR TITLE
Update the link in the docblock of "core multisite-convert" command

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -414,7 +414,7 @@ class Core_Command extends WP_CLI_Command {
 	 * For those using WordPress with Apache, remember to update the `.htaccess`
 	 * file with the appropriate multisite rewrite rules.
 	 *
-	 * [Review the multisite documentation](https://codex.wordpress.org/Create_A_Network)
+	 * [Review the multisite documentation](https://wordpress.org/support/article/create-a-network/)
 	 * for more details about how multisite works.
 	 *
 	 * ## OPTIONS


### PR DESCRIPTION
Or maybe it's just better to remove the link from the docblock because it seems like that having it here is a quite rare case for the codebase of wp-cli. Usually, there are no links in docblocks.
It's up to you, dear review :)
