### PR TITLE
Remove only themes/plugins folders on `--skip-content`

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -368,6 +368,7 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+    And the wp-includes directory should exist
     And the wp-content/plugins directory should not exist
 
   Scenario: Core download without the wp-content/themes dir should work non US locale
@@ -378,6 +379,7 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+    And the wp-includes directory should exist
     And the wp-content/themes directory should not exist
 
   Scenario: Core download without the wp-content/plugins dir should work if a version is set

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -340,7 +340,7 @@ Feature: Download WordPress
     """
     And the return code should be 1
 
-  Scenario: Core download without the wp-content dir
+  Scenario: Core download without the wp-content/plugins dir
     Given an empty directory
 
     When I run `wp core download --skip-content`
@@ -348,10 +348,19 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
-    And the wp-includes directory should exist
-    And the wp-content directory should not exist
+    And the wp-content/plugins directory should not exist
 
-  Scenario: Core download without the wp-content dir should work non US locale
+  Scenario: Core download without the wp-content/themes dir
+    Given an empty directory
+
+    When I run `wp core download --skip-content`
+    Then STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+    And the wp-content/themes directory should not exist
+
+  Scenario: Core download without the wp-content/plugins dir should work non US locale
     Given an empty directory
 
     When I run `wp core download --skip-content --version=4.9.11 --locale=nl_NL`
@@ -359,10 +368,29 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
-    And the wp-includes directory should exist
-    And the wp-content directory should not exist
+    And the wp-content/plugins directory should not exist
 
-  Scenario: Core download without the wp-content dir should work if a version is set
+  Scenario: Core download without the wp-content/themes dir should work non US locale
+    Given an empty directory
+
+    When I run `wp core download --skip-content --version=4.9.11 --locale=nl_NL`
+    Then STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+    And the wp-content/themes directory should not exist
+
+  Scenario: Core download without the wp-content/plugins dir should work if a version is set
+    Given an empty directory
+
+    When I try `wp core download --skip-content --version=4.7`
+    Then STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+    And the wp-content/plugins directory should not exist
+
+  Scenario: Core download without the wp-content/themes dir should work if a version is set
     Given an empty directory
 
     When I try `wp core download --skip-content --version=4.7`

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -348,6 +348,7 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+    And the wp-includes directory should exist
     And the wp-content/plugins directory should not exist
 
   Scenario: Core download without the wp-content/themes dir
@@ -358,6 +359,7 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+    And the wp-includes directory should exist
     And the wp-content/themes directory should not exist
 
   Scenario: Core download without the wp-content/plugins dir should work non US locale
@@ -390,6 +392,7 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+    And the wp-includes directory should exist
     And the wp-content/plugins directory should not exist
 
   Scenario: Core download without the wp-content/themes dir should work if a version is set

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -394,17 +394,7 @@ Feature: Download WordPress
       """
     And the wp-includes directory should exist
     And the wp-content/plugins directory should not exist
-
-  Scenario: Core download without the wp-content/themes dir should work if a version is set
-    Given an empty directory
-
-    When I try `wp core download --skip-content --version=4.7`
-    Then STDOUT should contain:
-      """
-      Success: WordPress downloaded.
-      """
-    And the wp-includes directory should exist
-    And the wp-content directory should not exist
+    And the wp-content/themes directory should not exist
 
   Scenario: Core download with extract parameter should unzip the download file
     Given an empty directory

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1517,7 +1517,7 @@ EOT;
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			for ( $i = 0; $i < $zip->numFiles; $i++ ) {
 				$info = $zip->statIndex( $i );
-				if ( false !== stripos( $info['name'], 'wp-content/' ) ) {
+				if ( false !== stripos( $info['name'], 'themes/' ) || false !== stripos( $info['name'], 'plugins/' ) ) {
 					$zip->deleteIndex( $i );
 				}
 			}


### PR DESCRIPTION
<em><strong>Moved over from PR #156:</strong></em>

Pull request https://github.com/wp-cli/core-command/pull/59 strips the whole wp-content directory, removing languages too and raising the issue that --locale= flag is broken.

I just changed the if-statement to strip out plugins and themes separately.

No idea how to write tests for that, it is a fairly simple fix.

Closes https://github.com/wp-cli/core-command/issues/147.