### PR TITLE
Fix deprecation notices in PHP 8.1

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -926,7 +926,7 @@ EOT;
 			);
 		}
 
-		$version_content = file_get_contents( $versions_path, null, null, 6, 2048 );
+		$version_content = file_get_contents( $versions_path, false, null, 6, 2048 );
 
 		$vars   = [ 'wp_version', 'wp_db_version', 'tinymce_version', 'wp_local_package' ];
 		$result = [];
@@ -988,7 +988,7 @@ EOT;
 	 * @return string|array String message on failure. An array of checksums on success.
 	 */
 	private static function get_core_checksums( $version, $locale, $insecure ) {
-		$query = http_build_query( compact( 'version', 'locale' ), null, '&' );
+		$query = http_build_query( compact( 'version', 'locale' ), '', '&' );
 		$url   = "https://api.wordpress.org/core/checksums/1.0/?{$query}";
 
 		$headers = [ 'Accept' => 'application/json' ];


### PR DESCRIPTION
`wp core version` produces:

```
Deprecated: file_get_contents(): Passing null to parameter #2 ($use_include_path) of type bool is deprecated in /Users/danielbachhuber/projects/wp-cli-dev/core-command/src/Core_Command.php on line 929
```

`wp core download --force` produces:

```
Deprecated: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in /Users/danielbachhuber/projects/wp-cli-dev/core-command/src/Core_Command.php on line 991
```

Fixes #219 