### PR TITLE
Fix failing tests by switching to WordPress 4.1 as minor update test

### DIFF
--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -37,14 +37,14 @@ Feature: Update WordPress core
     Given a WP install
     And I try `wp theme install twentytwenty --activate`
 
-    When I run `wp core download --version=3.7.9 --force`
+    When I run `wp core download --version=4.1 --force`
     Then STDOUT should not be empty
 
     # WP core throws notice for PHP 8+.
     When I try `wp core update --minor`
     Then STDOUT should contain:
       """
-      Updating to version {WP_VERSION-3.7-latest}
+      Updating to version {WP_VERSION-4.1-latest}
       """
     And STDOUT should contain:
       """
@@ -60,7 +60,7 @@ Feature: Update WordPress core
     When I run `wp core version`
     Then STDOUT should be:
       """
-      {WP_VERSION-3.7-latest}
+      {WP_VERSION-4.1-latest}
       """
 
   Scenario: Update to the latest minor release (PHP 7.1 compatible with WP >= 3.9)


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/5720
See https://github.com/wp-cli/wp-cli/issues/5705