### PR TITLE
Resolve tests failures from WordPress 6.2

### DIFF
--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -40,21 +40,3 @@ Feature: Check for more recent versions
       """
       1
       """
-
-  Scenario: No minor updates for an unlocalized WordPress release
-    Given a WP install
-    And I try `wp theme install twentytwenty --activate`
-
-    # If current WP_VERSION is nightly, trunk or old then from checksums might not exist, so STDERR may or may not be empty.
-    When I try `wp core download --version=4.0 --locale=es_ES --force`
-    Then STDOUT should contain:
-      """
-      Success: WordPress downloaded.
-      """
-    And the return code should be 0
-
-    # WP core throws notice for PHP 8+.
-    When I try `wp core check-update --minor`
-    Then STDOUT should be a table containing rows:
-      | version                 | update_type | package_url                                                                             |
-      | {WP_VERSION-4.0-latest} | minor       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-4.0-latest}-partial-0.zip |

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -322,41 +322,6 @@ Feature: Update WordPress core
     When I run `wp post create --post_title='Test post' --porcelain`
     Then STDOUT should be a number
 
-  @less-than-php-7.3
-  Scenario: Minor update on an unlocalized WordPress release
-    Given a WP install
-    And I try `wp theme install twentytwenty --activate`
-    And an empty cache
-
-    # If current WP_VERSION is nightly, trunk or old then from checksums might not exist, so STDERR may or may not be empty.
-    When I try `wp core download --version=4.0 --locale=es_ES --force`
-    Then STDOUT should contain:
-      """
-      Success: WordPress downloaded.
-      """
-    And the return code should be 0
-
-    # No checksums available for this WP version/locale
-    Given I run `wp option set WPLANG es_ES`
-    When I try `wp core update --minor`
-    Then STDOUT should contain:
-      """
-      Updating to version {WP_VERSION-4.0-latest} (en_US)...
-      """
-    And STDOUT should contain:
-      """
-      https://downloads.wordpress.org/release/wordpress-{WP_VERSION-4.0-latest}-partial-0.zip
-      """
-    And STDOUT should contain:
-      """
-      Success: WordPress updated successfully.
-      """
-    And STDERR should be:
-      """
-      Warning: Checksums not available for WordPress {WP_VERSION-4.0-latest}/es_ES. Please cleanup files manually.
-      """
-    And the return code should be 0
-
   @require-php-5.6
   Scenario Outline: Use `--version=(nightly|trunk)` to update to the latest nightly version
     Given a WP install

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -67,22 +67,18 @@ Feature: Update WordPress core
     Given a WP install
     And I try `wp theme install twentytwenty --activate`
 
-    When I run `wp core download --version=3.9.9 --force`
+    When I run `wp core download --version=4.1.30 --force`
     Then STDOUT should not be empty
 
     # This version of WP throws a PHP notice
     When I try `wp core update --minor`
     Then STDOUT should contain:
       """
-      Updating to version {WP_VERSION-3.9-latest}
+      Updating to version {WP_VERSION-4.1-latest}
       """
     And STDOUT should contain:
       """
       Success: WordPress updated successfully.
-      """
-    And STDERR should contain:
-      """
-      Undefined variable
       """
     And the return code should be 0
 
@@ -95,7 +91,7 @@ Feature: Update WordPress core
     When I run `wp core version`
     Then STDOUT should be:
       """
-      {WP_VERSION-3.9-latest}
+      {WP_VERSION-4.1-latest}
       """
 
   Scenario: Core update from cache


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/5764

* Updates one test to use a newer minor version that still has a download offer.
* Removes another test that covers an esoteric condition we can no longer reproduce. It was originally introduced in https://github.com/wp-cli/wp-cli/pull/2469