### PR TITLE
Leave `wp-content/plugins` and `wp-content/themes` directories when using `--skip-content`

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -340,7 +340,7 @@ Feature: Download WordPress
     """
     And the return code should be 1
 
-  Scenario: Core download without the wp-content/plugins dir
+  Scenario: Core download without the full wp-content/plugins dir
     Given an empty directory
 
     When I run `wp core download --skip-content`
@@ -349,10 +349,14 @@ Feature: Download WordPress
       Success: WordPress downloaded.
       """
     And the wp-includes directory should exist
-    And the wp-content/plugins directory should not exist
+    And the wp-content/plugins directory should exist
+    And the wp-content/plugins directory should be:
+      """
+      index.php
+      """
     And the wp-includes/js/tinymce/plugins directory should exist
 
-  Scenario: Core download without the wp-content/themes dir
+  Scenario: Core download without the full wp-content/themes dir
     Given an empty directory
 
     When I run `wp core download --skip-content`
@@ -361,10 +365,14 @@ Feature: Download WordPress
       Success: WordPress downloaded.
       """
     And the wp-includes directory should exist
-    And the wp-content/themes directory should not exist
+    And the wp-content/themes directory should exist
+    And the wp-content/themes directory should be:
+       """
+       index.php
+       """
     And the wp-includes/js/tinymce/themes directory should exist
 
-  Scenario: Core download without the wp-content/plugins dir should work non US locale
+  Scenario: Core download without the full wp-content/plugins dir should work non US locale
     Given an empty directory
 
     When I run `wp core download --skip-content --version=4.9.11 --locale=nl_NL`
@@ -373,10 +381,14 @@ Feature: Download WordPress
       Success: WordPress downloaded.
       """
     And the wp-includes directory should exist
-    And the wp-content/plugins directory should not exist
+    And the wp-content/plugins directory should exist
+    And the wp-content/plugins directory should be:
+       """
+       index.php
+       """
     And the wp-includes/js/tinymce/plugins directory should exist
 
-  Scenario: Core download without the wp-content/themes dir should work non US locale
+  Scenario: Core download without the full wp-content/themes dir should work non US locale
     Given an empty directory
 
     When I run `wp core download --skip-content --version=4.9.11 --locale=nl_NL`
@@ -385,10 +397,14 @@ Feature: Download WordPress
       Success: WordPress downloaded.
       """
     And the wp-includes directory should exist
-    And the wp-content/themes directory should not exist
+    And the wp-content/themes directory should exist
+    And the wp-content/themes directory should be:
+       """
+       index.php
+       """
     And the wp-includes/js/tinymce/themes directory should exist
 
-  Scenario: Core download without the wp-content/plugins dir should work if a version is set
+  Scenario: Core download without the full wp-content/plugins dir should work if a version is set
     Given an empty directory
 
     When I try `wp core download --skip-content --version=4.7`
@@ -397,8 +413,16 @@ Feature: Download WordPress
       Success: WordPress downloaded.
       """
     And the wp-includes directory should exist
-    And the wp-content/plugins directory should not exist
-    And the wp-content/themes directory should not exist
+    And the wp-content/plugins directory should exist
+    And the wp-content/plugins directory should be:
+       """
+       index.php
+       """
+    And the wp-content/themes directory should exist
+    And the wp-content/themes directory should be:
+       """
+       index.php
+       """
     And the wp-includes/js/tinymce/themes directory should exist
     And the wp-includes/js/tinymce/plugins directory should exist
 

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1524,6 +1524,21 @@ EOT;
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			for ( $i = 0; $i < $zip->numFiles; $i++ ) {
 				$info = $zip->statIndex( $i );
+				// Strip all files in wp-content/themes and wp-content/plugins
+				// but leave the directories and index.php files intact.
+				if ( in_array(
+					$info['name'],
+					array(
+						'wordpress/wp-content/plugins/',
+						'wordpress/wp-content/plugins/index.php',
+						'wordpress/wp-content/themes/',
+						'wordpress/wp-content/themes/index.php',
+					),
+					true
+				) ) {
+					continue;
+				}
+
 				if ( 0 === stripos( $info['name'], 'wordpress/wp-content/themes/' ) || 0 === stripos( $info['name'], 'wordpress/wp-content/plugins/' ) ) {
 					$zip->deleteIndex( $i );
 				}


### PR DESCRIPTION
Creates the `wp-content/plugins` and `wp-content/themes` directories (and their corresponding `index.php` files) when using `wp core download --skip-content`, instead of ignoring them.

While these directories were intentionally excluded in the [original pull request](https://github.com/wp-cli/core-command/pull/37)...
* Installing a WordPress plugin in the admin fails if the directory doesn't exist.
* The intent of the original pull request was to exclude default plugins and themes.
* We're creating the `wp-content` directory anyway ([pull request](https://github.com/wp-cli/core-command/pull/212)), so I don't think it's rational to create `wp-content` but not `wp-content/plugins`.

I'm not sure if we should consider this a breaking change, or a bug with the original implementation.

Fixes https://github.com/wp-cli/core-command/issues/228