### PR TITLE
Feat: provide support to skip config for multisite convert

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -449,6 +449,9 @@ class Core_Command extends WP_CLI_Command {
 	 * [--subdomains]
 	 * : If passed, the network will use subdomains, instead of subdirectories. Doesn't work with 'localhost'.
 	 *
+	 * [--skip-config]
+	 * : Don't add multisite constants to wp-config.php.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp core multisite-convert


### PR DESCRIPTION
## Issue 
- #178 
- Need to add `--skip-config` parameter so that user have an option to not add the config parameters to `wp-config.php` file while using the command `wp core multisite-convert`.

## Solution
- Have added the `--skip-config` parameter to subcommand function doc block.
- This enables the command to use `--skip-config`.
- Only adding this parameter to comment works as needed on issue as the `multisite-install` and `multisite-convert` command have a common function `multisite_convert_( $assoc_args )` which have a check for this parameter and then proceed accordingly.

## Screenshot for command executed after the patch:
<img width="1440" alt="Screenshot 2023-05-22 at 7 57 35 PM" src="https://github.com/wp-cli/core-command/assets/58802366/1e71eaad-66d9-4913-8dce-19c659e6aed5">

