### PR TITLE
Directly pass empty or missing password parameter to WordPress

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -637,9 +637,7 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		$public   = true;
-		$password = empty( $args['admin_password'] )
-			? wp_generate_password( 18 )
-			: $args['admin_password'];
+		$password = $args['admin_password'];
 
 		if ( ! is_email( $args['admin_email'] ) ) {
 			WP_CLI::error( "The '{$args['admin_email']}' email address is invalid." );


### PR DESCRIPTION
### Issue

- #183 
- If the `--admin_password` parameter is missing or an empty value is passed while executing core install commands, the password should not be generated on WP-CLI command side, rather should be passed as it is to `wp_install()` for WordPress to internally generate it, which in that case will also send the auto-generated password through the new blog email to the admin user.

### Testing

In the current tests email content is not tested. Therefore didn't attach a test for this change. Please let me know if a test is needed.

### "New Blog" email before and after the change

Before the change even if password is not supplied through parameter and random password is generated, it is not send through email -

![image](https://github.com/wp-cli/core-command/assets/39427067/f6e9ed76-823a-449c-a884-55cf52bf8b3c)

But after the change, if random password is generated then that is send through the email -

![image](https://github.com/wp-cli/core-command/assets/39427067/72903fc1-d420-4c16-b600-7ccc1c283f55)

