### PR TITLE
Check more files to determine if WordPress is present or not

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -137,10 +137,13 @@ class Core_Command extends WP_CLI_Command {
 			? ( rtrim( $assoc_args['path'], '/\\' ) . '/' )
 			: ABSPATH;
 
-		$wordpress_present = is_readable( $download_dir . 'wp-load.php' );
+		// To check the entire directory for WordPress files.
+		$wordpress_present = preg_grep( '~^wp-.*\.php$~', scandir( $download_dir ) );
 
-		if ( $wordpress_present && ! Utils\get_flag_value( $assoc_args, 'force' ) ) {
-			WP_CLI::error( 'WordPress files seem to already be present here.' );
+		// Check if files are present and --force is not given as param.
+		// Confirm user to download the WordPress core.
+		if ( is_array( $wordpress_present ) && ! empty( $wordpress_present ) && ! Utils\get_flag_value( $assoc_args, 'force' ) ) {
+			WP_CLI::confirm( 'WordPress files seem to already be present here. Would you like to continue?' );
 		}
 
 		if ( ! is_dir( $download_dir ) ) {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -137,13 +137,14 @@ class Core_Command extends WP_CLI_Command {
 			? ( rtrim( $assoc_args['path'], '/\\' ) . '/' )
 			: ABSPATH;
 
-		// To check the entire directory for WordPress files.
-		$wordpress_present = preg_grep( '~^wp-.*\.php$~', scandir( $download_dir ) );
+		// Check for files if WordPress already present or not.
+		$wordpress_present = is_readable( $download_dir . 'wp-load.php' )
+			|| is_readable( $download_dir . 'wp-mail.php' )
+			|| is_readable( $download_dir . 'wp-cron.php' )
+			|| is_readable( $download_dir . 'wp-links-opml.php' );
 
-		// Check if files are present and --force is not given as param.
-		// Confirm user to download the WordPress core.
-		if ( is_array( $wordpress_present ) && ! empty( $wordpress_present ) && ! Utils\get_flag_value( $assoc_args, 'force' ) ) {
-			WP_CLI::confirm( 'WordPress files seem to already be present here. Would you like to continue?' );
+		if ( $wordpress_present && ! Utils\get_flag_value( $assoc_args, 'force' ) ) {
+			WP_CLI::error( 'WordPress files seem to already be present here.' );
 		}
 
 		if ( ! is_dir( $download_dir ) ) {


### PR DESCRIPTION
## Issue

- #164 

## Description
- If a user has an empty directory and then adds the empty wp-load.php file and runs `wp core download`, it would throw an error saying `WordPress files seem to already be present here.` This is only dependent point for this command to identify the WordPress files are present or not.

## Solution
- Instead of a single file check, we can modify the command file and can check for multiple file as here - https://gist.github.com/danielbachhuber/9b137817e119321f03b9d09df855b3fb, as per https://github.com/wp-cli/core-command/issues/164#issuecomment-1559360017 comment as of now we don't require much complex solution so just can check for 3–4 files in directory and notify the user for the same.

## Test
- Have run the behat test and all tests pass successfully, I did not exactly know if we required to add the test's because there is already a general test written for this kind of scenario, https://github.com/wp-cli/core-command/blob/e3212a3e18fe4affabc54c76cc6a59f3d8059d24/features/core.feature#L293-L302

Cc: @danielbachhuber 