### PR TITLE
Fix tests for Requests v2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wp-cli/db-command": "^1.3 || ^2",
         "wp-cli/entity-command": "^1.3 || ^2",
         "wp-cli/extension-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^3.1.4"
+        "wp-cli/wp-cli-tests": "^3.2.7"
     },
     "config": {
         "process-timeout": 7200,

--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -4,14 +4,14 @@ Feature: Check for more recent versions
     Given a WP install
     And I try `wp theme install twentytwenty --activate`
 
-    When I run `wp core download --version=4.4 --force`
+    When I run `wp core download --version=5.8 --force`
     Then STDOUT should not be empty
 
     When I run `wp core check-update`
     Then STDOUT should be a table containing rows:
       | version                 | update_type | package_url                                                                             |
       | {WP_VERSION-latest}     | major       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-latest}.zip               |
-      | {WP_VERSION-4.4-latest} | minor       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-4.4-latest}-partial-0.zip |
+      | {WP_VERSION-5.8-latest} | minor       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip |
 
     When I run `wp core check-update --format=count`
     Then STDOUT should be:
@@ -33,7 +33,7 @@ Feature: Check for more recent versions
     When I run `wp core check-update --minor`
     Then STDOUT should be a table containing rows:
       | version                 | update_type | package_url                                                                             |
-      | {WP_VERSION-4.4-latest} | minor       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-4.4-latest}-partial-0.zip |
+      | {WP_VERSION-5.8-latest} | minor       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip |
 
     When I run `wp core check-update --minor --format=count`
     Then STDOUT should be:

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -16,7 +16,6 @@ Feature: Download WordPress
     And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
     Then the wp-settings.php file should exist
     And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-{WP_VERSION-latest}-en_US.tar.gz file should exist
 
     When I run `mkdir inner`
     And I run `cd inner && wp core download`

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -68,7 +68,10 @@ Feature: Update WordPress core
     And I try `wp theme install twentytwenty --activate`
 
     When I run `wp core download --version=4.1.30 --force`
-    Then STDOUT should not be empty
+    Then STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
 
     # This version of WP throws a PHP notice
     When I try `wp core update --minor`
@@ -260,6 +263,10 @@ Feature: Update WordPress core
     Then the wp-includes/Requests/Exception/Transport/Curl.php file should not exist
     Then the wp-includes/Requests/Exception/Http/Status502.php file should not exist
     Then the wp-includes/Requests/Iri.php file should not exist
+    And STDOUT should contain:
+      """
+      Success: WordPress updated successfully.
+      """
 
     When I run `wp core update --version=5.9-beta1 --force`
     Then the wp-includes/Requests/Transport/cURL.php file should not exist

--- a/src/WP_CLI/Core/CoreUpgrader.php
+++ b/src/WP_CLI/Core/CoreUpgrader.php
@@ -3,7 +3,6 @@
 namespace WP_CLI\Core;
 
 use Exception;
-use Requests_Response;
 use WP_CLI;
 use WP_CLI\Utils;
 use WP_Error;
@@ -27,7 +26,7 @@ class CoreUpgrader extends DefaultCoreUpgrader {
 	/**
 	 * CoreUpgrader constructor.
 	 *
-	 * @param WP_Upgrader_Skin|null $skin
+	 * @param \WP_Upgrader_Skin|null $skin
 	 */
 	public function __construct( $skin = null, $insecure = false ) {
 		$this->insecure = $insecure;
@@ -115,7 +114,7 @@ class CoreUpgrader extends DefaultCoreUpgrader {
 
 		$this->skin->feedback( 'downloading_package', $package );
 
-		/** @var Requests_Response|null $req */
+		/** @var \Requests_Response|\WpOrg\Requests\Response null $req */
 		try {
 			$response = Utils\http_request( 'GET', $package, null, $headers, $options );
 		} catch ( Exception $e ) {


### PR DESCRIPTION
This PR makes a few minor changes to get the tests to pass with the new Requests v2 integration.