### PR TITLE
Fix spelling for filesystem

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -96,7 +96,7 @@ class Core_Command extends WP_CLI_Command {
 	 *
 	 * Downloads and extracts WordPress core files to the specified path. Uses
 	 * current directory when no path is specified. Downloaded build is verified
-	 * to have the correct md5 and then cached to the local filesytem.
+	 * to have the correct md5 and then cached to the local filesystem.
 	 * Subsequent uses of command will use the local cache if it still exists.
 	 *
 	 * ## OPTIONS


### PR DESCRIPTION
**Path:**

`/Users/nilambarsharma/Work/wp-git/core-command/src/Core_Command.php` L99

**Change:**

`filesytem` ->  `filesystem`