### PR TITLE
Update trunk test to require PHP 7.2

### DIFF
--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -340,7 +340,7 @@ Feature: Update WordPress core
     When I run `wp post create --post_title='Test post' --porcelain`
     Then STDOUT should be a number
 
-  @require-php-7.0
+  @require-php-7.2
   Scenario Outline: Use `--version=(nightly|trunk)` to update to the latest nightly version
     Given a WP install
 
@@ -360,7 +360,7 @@ Feature: Update WordPress core
     | trunk      |
     | nightly    |
 
-  @require-php-7.0
+  @require-php-7.2
   Scenario: Installing latest nightly build should skip cache
     Given a WP install
 


### PR DESCRIPTION
Failing test run: https://github.com/wp-cli/core-command/actions/runs/8655659251/job/23735026056#step:11:109

Needed because of https://core.trac.wordpress.org/changeset/57985