### PR TITLE
Composer: prevent a lock file from being created

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "johnpbloch/wordpress-core-installer": true
-        }
+        },
+        "lock": false
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This is a useful option for packages such as this where the  file has no meaning.