### PR TITLE
Fix failing tests

### DIFF
--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -13,7 +13,7 @@ Feature: Check for more recent versions
     Then STDOUT should be a table containing rows:
       | version                 | update_type | package_url                                                                             |
       | {WP_VERSION-latest}     | major       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-latest}.zip               |
-      | {WP_VERSION-5.8-latest} | minor       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip |
+      | {WP_VERSION-5.8-latest} | minor       | https://downloads.w.org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip |
 
     When I run `wp core check-update --format=count`
     Then STDOUT should be:
@@ -35,7 +35,7 @@ Feature: Check for more recent versions
     When I run `wp core check-update --minor`
     Then STDOUT should be a table containing rows:
       | version                 | update_type | package_url                                                                             |
-      | {WP_VERSION-5.8-latest} | minor       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip |
+      | {WP_VERSION-5.8-latest} | minor       | https://downloads.w.org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip |
 
     When I run `wp core check-update --minor --format=count`
     Then STDOUT should be:

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -276,6 +276,10 @@ Feature: Update WordPress core
     Then the wp-includes/Requests/src/Iri.php file should not exist
     And STDOUT should contain:
       """
+      Cleaning up files...
+      """
+    And STDOUT should contain:
+      """
       Success: WordPress updated successfully.
       """
 
@@ -288,51 +292,9 @@ Feature: Update WordPress core
     Then the wp-includes/Requests/src/Exception/Transport/Curl.php file should exist
     Then the wp-includes/Requests/src/Exception/Http/Status502.php file should exist
     Then the wp-includes/Requests/src/Iri.php file should exist
-    Then STDOUT should contain:
+    And STDOUT should contain:
       """
-      File removed: wp-includes/Requests/Transport/fsockopen.php
-      File removed: wp-includes/Requests/Transport/cURL.php
-      File removed: wp-includes/Requests/Hooker.php
-      File removed: wp-includes/Requests/IPv6.php
-      File removed: wp-includes/Requests/Exception/Transport/cURL.php
-      File removed: wp-includes/Requests/Exception/HTTP.php
-      File removed: wp-includes/Requests/Exception/HTTP/502.php
-      File removed: wp-includes/Requests/Exception/HTTP/Unknown.php
-      File removed: wp-includes/Requests/Exception/HTTP/412.php
-      File removed: wp-includes/Requests/Exception/HTTP/408.php
-      File removed: wp-includes/Requests/Exception/HTTP/431.php
-      File removed: wp-includes/Requests/Exception/HTTP/501.php
-      File removed: wp-includes/Requests/Exception/HTTP/500.php
-      File removed: wp-includes/Requests/Exception/HTTP/407.php
-      File removed: wp-includes/Requests/Exception/HTTP/416.php
-      File removed: wp-includes/Requests/Exception/HTTP/428.php
-      File removed: wp-includes/Requests/Exception/HTTP/406.php
-      File removed: wp-includes/Requests/Exception/HTTP/504.php
-      File removed: wp-includes/Requests/Exception/HTTP/411.php
-      File removed: wp-includes/Requests/Exception/HTTP/414.php
-      File removed: wp-includes/Requests/Exception/HTTP/511.php
-      File removed: wp-includes/Requests/Exception/HTTP/410.php
-      File removed: wp-includes/Requests/Exception/HTTP/403.php
-      File removed: wp-includes/Requests/Exception/HTTP/400.php
-      File removed: wp-includes/Requests/Exception/HTTP/505.php
-      File removed: wp-includes/Requests/Exception/HTTP/413.php
-      File removed: wp-includes/Requests/Exception/HTTP/404.php
-      File removed: wp-includes/Requests/Exception/HTTP/306.php
-      File removed: wp-includes/Requests/Exception/HTTP/304.php
-      File removed: wp-includes/Requests/Exception/HTTP/405.php
-      File removed: wp-includes/Requests/Exception/HTTP/429.php
-      File removed: wp-includes/Requests/Exception/HTTP/417.php
-      File removed: wp-includes/Requests/Exception/HTTP/409.php
-      File removed: wp-includes/Requests/Exception/HTTP/402.php
-      File removed: wp-includes/Requests/Exception/HTTP/418.php
-      File removed: wp-includes/Requests/Exception/HTTP/305.php
-      File removed: wp-includes/Requests/Exception/HTTP/415.php
-      File removed: wp-includes/Requests/Exception/HTTP/401.php
-      File removed: wp-includes/Requests/Exception/HTTP/503.php
-      File removed: wp-includes/Requests/IRI.php
-      File removed: wp-includes/Requests/IDNAEncoder.php
-      File removed: wp-includes/Requests/SSL.php
-      File removed: wp-includes/Requests/Proxy/HTTP.php
+      Cleaning up files...
       """
 
     When I run `wp option add str_opt 'bar'`

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -263,6 +263,12 @@ Feature: Update WordPress core
   @require-mysql
   Scenario: Make sure files are cleaned up with mixed case
     Given a WP install
+    And a wp-content/mu-plugins/silence-requests-deprecation.php file:
+      """
+      <?php
+      define( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS', true );
+      """
+
     And I try `wp theme install twentytwenty --activate`
 
     When I run `wp core update --version=5.8 --force`

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -263,12 +263,6 @@ Feature: Update WordPress core
   @require-mysql
   Scenario: Make sure files are cleaned up with mixed case
     Given a WP install
-    And a wp-content/mu-plugins/silence-requests-deprecation.php file:
-      """
-      <?php
-      define( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS', true );
-      """
-
     And I try `wp theme install twentytwenty --activate`
 
     When I run `wp core update --version=5.8 --force`

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -270,10 +270,10 @@ Feature: Update WordPress core
     Then the wp-includes/Requests/Exception/Transport/cURL.php file should exist
     Then the wp-includes/Requests/Exception/HTTP/502.php file should exist
     Then the wp-includes/Requests/IRI.php file should exist
-    Then the wp-includes/Requests/Transport/Curl.php file should not exist
-    Then the wp-includes/Requests/Exception/Transport/Curl.php file should not exist
-    Then the wp-includes/Requests/Exception/Http/Status502.php file should not exist
-    Then the wp-includes/Requests/Iri.php file should not exist
+    Then the wp-includes/Requests/src/Transport/Curl.php file should not exist
+    Then the wp-includes/Requests/src/Exception/Transport/Curl.php file should not exist
+    Then the wp-includes/Requests/src/Exception/Http/Status502.php file should not exist
+    Then the wp-includes/Requests/src/Iri.php file should not exist
     And STDOUT should contain:
       """
       Success: WordPress updated successfully.
@@ -284,10 +284,10 @@ Feature: Update WordPress core
     Then the wp-includes/Requests/Exception/Transport/cURL.php file should not exist
     Then the wp-includes/Requests/Exception/HTTP/502.php file should not exist
     Then the wp-includes/Requests/IRI.php file should not exist
-    Then the wp-includes/Requests/Transport/Curl.php file should exist
-    Then the wp-includes/Requests/Exception/Transport/Curl.php file should exist
-    Then the wp-includes/Requests/Exception/Http/Status502.php file should exist
-    Then the wp-includes/Requests/Iri.php file should exist
+    Then the wp-includes/Requests/src/Transport/Curl.php file should exist
+    Then the wp-includes/Requests/src/Exception/Transport/Curl.php file should exist
+    Then the wp-includes/Requests/src/Exception/Http/Status502.php file should exist
+    Then the wp-includes/Requests/src/Iri.php file should exist
     Then STDOUT should contain:
       """
       File removed: wp-includes/Requests/Transport/fsockopen.php

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -259,7 +259,7 @@ Feature: Update WordPress core
     When I run `wp post create --post_title='Test post' --porcelain`
     Then STDOUT should be a number
 
-  # This test downgrades to an older WordPress version, but the SQLite plugin requires 6.0+
+  # This test downgrades to an older WordPress version, but the SQLite plugin requires 6.4+
   @require-mysql
   Scenario: Make sure files are cleaned up with mixed case
     Given a WP install
@@ -279,7 +279,7 @@ Feature: Update WordPress core
       Success: WordPress updated successfully.
       """
 
-    When I run `wp core update --version=5.9-beta1 --force`
+    When I run `wp core update --version=6.2 --force`
     Then the wp-includes/Requests/Transport/cURL.php file should not exist
     Then the wp-includes/Requests/Exception/Transport/cURL.php file should not exist
     Then the wp-includes/Requests/Exception/HTTP/502.php file should not exist


### PR DESCRIPTION
At the moment we don't hide PHP warnings and deprecations in Behat tests anymore, which helps surface potential issues with the tess.

There is currently 1 test failing because of that.

Example test run: https://github.com/wp-cli/core-command/actions/runs/11136463362/job/30948399200#step:11:36

```
001 Scenario: Make sure files are cleaned up with mixed case # features/core-update.feature:264
      Then STDOUT should be a number                         # features/core-update.feature:341
        Actual value: 'Deprecated: The PSR-0 `Requests_...` class names in the Request library are deprecated. Switch to the PSR-4 `WpOrg\\Requests\\...` class names at your earliest convenience. in /tmp/wp-cli-test-run--66fcaeaf29b076.48217376/wp-includes/class-requests.php on line 24
        4' (Exception)
```

This fix should address this warning.