### PR TITLE
Require `wp-cli/wp-cli` v2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "composer/semver": "^1.4 || ^2 || ^3",
-        "wp-cli/wp-cli": "^2.5.1"
+        "wp-cli/wp-cli": "^2.12"
     },
     "require-dev": {
         "wp-cli/checksum-command": "^1 || ^2",


### PR DESCRIPTION
For improved PHP 8.4 compatibility.