### PR TITLE
Fix flaky tests due to changing download URL

### DIFF
--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -9,11 +9,9 @@ Feature: Check for more recent versions
     When I run `wp core download --version=5.8 --force`
     Then STDOUT should not be empty
 
-    When I run `wp core check-update`
-    Then STDOUT should be a table containing rows:
-      | version                 | update_type | package_url                                                                             |
-      | {WP_VERSION-latest}     | major       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-latest}.zip               |
-      | {WP_VERSION-5.8-latest} | minor       | https://downloads.w.org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip |
+    When I run `wp core check-update --format=csv`
+    Then STDOUT should match #^{WP_VERSION-latest},major,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-latest}.zip$#
+    And STDOUT should match #^{WP_VERSION-5.8-latest},minor,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip$#
 
     When I run `wp core check-update --format=count`
     Then STDOUT should be:
@@ -21,10 +19,8 @@ Feature: Check for more recent versions
       2
       """
 
-    When I run `wp core check-update --major`
-    Then STDOUT should be a table containing rows:
-      | version             | update_type | package_url                                                               |
-      | {WP_VERSION-latest} | major       | https://downloads.wordpress.org/release/wordpress-{WP_VERSION-latest}.zip |
+    When I run `wp core check-update --major --format=csv`
+    Then STDOUT should match #^{WP_VERSION-latest},major,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-latest}.zip$#
 
     When I run `wp core check-update --major --format=count`
     Then STDOUT should be:
@@ -33,9 +29,7 @@ Feature: Check for more recent versions
       """
 
     When I run `wp core check-update --minor`
-    Then STDOUT should be a table containing rows:
-      | version                 | update_type | package_url                                                                             |
-      | {WP_VERSION-5.8-latest} | minor       | https://downloads.w.org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip |
+    Then STDOUT should match #^{WP_VERSION-5.8-latest},minor,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip$#
 
     When I run `wp core check-update --minor --format=count`
     Then STDOUT should be:

--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -10,8 +10,8 @@ Feature: Check for more recent versions
     Then STDOUT should not be empty
 
     When I run `wp core check-update --format=csv`
-    Then STDOUT should match #^{WP_VERSION-latest},major,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-latest}.zip$#
-    And STDOUT should match #^{WP_VERSION-5.8-latest},minor,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip$#
+    Then STDOUT should match #{WP_VERSION-latest},major,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-latest}.zip#
+    And STDOUT should match #{WP_VERSION-5.8-latest},minor,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip#
 
     When I run `wp core check-update --format=count`
     Then STDOUT should be:
@@ -20,7 +20,7 @@ Feature: Check for more recent versions
       """
 
     When I run `wp core check-update --major --format=csv`
-    Then STDOUT should match #^{WP_VERSION-latest},major,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-latest}.zip$#
+    Then STDOUT should match #{WP_VERSION-latest},major,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-latest}.zip#
 
     When I run `wp core check-update --major --format=count`
     Then STDOUT should be:
@@ -29,7 +29,7 @@ Feature: Check for more recent versions
       """
 
     When I run `wp core check-update --minor`
-    Then STDOUT should match #^{WP_VERSION-5.8-latest},minor,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip$#
+    Then STDOUT should match #{WP_VERSION-5.8-latest},minor,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip#
 
     When I run `wp core check-update --minor --format=count`
     Then STDOUT should be:

--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -28,7 +28,7 @@ Feature: Check for more recent versions
       1
       """
 
-    When I run `wp core check-update --minor`
+    When I run `wp core check-update --minor --format=csv`
     Then STDOUT should match #{WP_VERSION-5.8-latest},minor,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip#
 
     When I run `wp core check-update --minor --format=count`


### PR DESCRIPTION
This is a follow-up to #272 where I previously tried to change the expected download URL for major/minor versions.

However this sometimes seems to change and thus tests fail.

This switches to a regex-based approach that matches both download URL patterns, `https://downloads.w.org/release/...` and `https://downloads.wordpress.org/release/...`