### PR TITLE
Fix tests for Hello Dolly

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -256,7 +256,7 @@ Feature: Manage WordPress installation
     Given a WP install
     And a custom wp-content directory
 
-    When I run `wp plugin status hello`
+    When I run `wp plugin status akismet`
     Then STDOUT should not be empty
 
   Scenario: User defined in wp-cli.yml


### PR DESCRIPTION
Hello Dolly was moved from a single file to a directory in WordPress 6.9