### PR TITLE
Unconditionally use `get_current_network_id`

### DIFF
--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1559,7 +1559,7 @@ EOT;
 
 		if ( $network ) {
 			// Determine the network ID to update.
-			// get_current_network_id reflects the network determined from the --url context
+			// get_current_network_id() reflects the network determined from the --url context,
 			// enabling per-network updates in multinetwork setups.
 			$network_id = get_current_network_id();
 

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1559,16 +1559,9 @@ EOT;
 
 		if ( $network ) {
 			// Determine the network ID to update.
-			// get_current_network_id() (available since WP 4.9) reflects the network
-			// determined from the --url context, enabling per-network updates in
-			// multinetwork setups. Fall back to SITE_ID_CURRENT_SITE for older WordPress.
-			if ( function_exists( 'get_current_network_id' ) ) {
-				$network_id = get_current_network_id();
-			} elseif ( defined( 'SITE_ID_CURRENT_SITE' ) ) {
-				$network_id = (int) SITE_ID_CURRENT_SITE;
-			} else {
-				$network_id = 1;
-			}
+			// get_current_network_id reflects the network determined from the --url context
+			// enabling per-network updates in multinetwork setups.
+			$network_id = get_current_network_id();
 
 			$iterator_args = [
 				'table' => $wpdb->blogs,


### PR DESCRIPTION
The function was actually introduced in WP 4.6 and we now require 4.9

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
