### PR TITLE
Always use ZIP archives for downloads

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -15,7 +15,7 @@ Feature: Download WordPress
     When I run `wp core download`
     And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
     Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.zip file should exist
 
     When I run `mkdir inner`
     And I run `cd inner && wp core download`
@@ -40,7 +40,7 @@ Feature: Download WordPress
     Then the wp-settings.php file should exist
     And STDOUT should contain:
       """
-      Using cached file '{SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz'...
+      Using cached file '{SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.zip'...
       """
 
   Scenario: Localized install
@@ -49,7 +49,7 @@ Feature: Download WordPress
     When I run `wp core download --version=4.4.2 --locale=de_DE`
     And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
     Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-de_DE.tar.gz file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-de_DE.zip file should exist
 
   Scenario: Error when requested locale is not available for the latest version
     Given an empty directory
@@ -150,7 +150,7 @@ Feature: Download WordPress
     When I run `wp core download --version=4.4.1`
     Then STDOUT should contain:
       """
-      md5 hash verified: 1907d1dbdac7a009d89224a516496b8d
+      md5 hash verified: 0c87de03eb3d76467cd0d3ab7268f1fd
       Success: WordPress downloaded.
       """
 
@@ -328,7 +328,7 @@ Feature: Download WordPress
     And STDOUT should contain:
       """
       Downloading WordPress 4.6-RC2 (en_US)...
-      md5 hash verified: 90c93a15092b2d5d4c960ec1fc183e07
+      md5 hash verified: dbf4a8fe1c54d1e3e28532402da9a743
       Success: WordPress downloaded.
       """
 
@@ -344,8 +344,8 @@ Feature: Download WordPress
 
     When I run `wp core version`
     Then save STDOUT as {VERSION}
-    And the {SUITE_CACHE_DIR}/core/wordpress-latest-en_US.tar.gz file should not exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-latest-en_US.zip file should not exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.zip file should exist
 
   Scenario: Fail if path can't be created
     Given an empty directory
@@ -503,14 +503,14 @@ Feature: Download WordPress
 
     When I run `wp core download --version=4.5 --locale=de_DE`
     Then the wp-content directory should exist
-    And the wordpress-4.5-de_DE.tar.gz file should not exist
+    And the wordpress-4.5-de_DE.zip file should not exist
 
   Scenario: Core download with extract parameter should unzip the download file
     Given an empty directory
 
     When I run `wp core download --version=4.5 --locale=de_DE --extract`
     Then the wp-content directory should exist
-    And the wordpress-4.5-de_DE.tar.gz file should not exist
+    And the wordpress-4.5-de_DE.zip file should not exist
 
   Scenario: Core download with extract parameter should unzip the download file (already cached)
     Given an empty directory
@@ -519,23 +519,23 @@ Feature: Download WordPress
     And I run `rm -rf *`
     And I run `wp core download --version=4.5 --locale=de_DE --extract`
     Then the wp-content directory should exist
-    And the wordpress-4.5-de_DE.tar.gz file should not exist
+    And the wordpress-4.5-de_DE.zip file should not exist
 
   Scenario: Core download with no-extract should not unzip the download file
     Given an empty directory
 
     When I run `wp core download --version=4.5 --locale=de_DE --no-extract`
     Then the wp-content directory should not exist
-    And the wordpress-4.5-de_DE.tar.gz file should exist
+    And the wordpress-4.5-de_DE.zip file should exist
 
   Scenario: Core download with no-extract should not unzip the download file (already cached)
     Given an empty directory
 
     When I run `wp core download --version=4.5 --locale=de_DE --no-extract`
-    And I run `rm -rf wordpress-4.5-de_DE.tar.gz`
+    And I run `rm -rf wordpress-4.5-de_DE.zip`
     And I run `wp core download --version=4.5 --locale=de_DE --no-extract`
     Then the wp-content directory should not exist
-    And the wordpress-4.5-de_DE.tar.gz file should exist
+    And the wordpress-4.5-de_DE.zip file should exist
 
   Scenario: Error when using both --skip-content and --no-extract
     Given an empty directory

--- a/features/core-install.feature
+++ b/features/core-install.feature
@@ -291,7 +291,7 @@ Feature: Install WordPress core
       5.6
       """
     And the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-de_DE.tar.gz file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-de_DE.zip file should exist
 
     When I run `wp config create --dbname={DB_NAME} --dbuser={DB_USER} --dbpass={DB_PASSWORD} --dbhost={DB_HOST} --locale=de_DE --skip-check`
     Then STDOUT should be:

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -226,7 +226,7 @@ Feature: Update WordPress core
       """
     And the {SUITE_CACHE_DIR}/core directory should contain:
       """
-      wordpress-6.5.2-en_US.tar.gz
+      wordpress-6.5.2-en_US.zip
       wordpress-6.5.5-partial-1-en_US.zip
       """
 
@@ -246,8 +246,8 @@ Feature: Update WordPress core
       """
     And the {SUITE_CACHE_DIR}/core directory should contain:
       """
-      wordpress-6.4.1-en_US.tar.gz
-      wordpress-6.5.2-en_US.tar.gz
+      wordpress-6.4.1-en_US.zip
+      wordpress-6.5.2-en_US.zip
       wordpress-6.5.5-no-content-en_US.zip
       wordpress-6.5.5-partial-1-en_US.zip
       """

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -298,8 +298,6 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		if ( ! $cache_file || $bad_cache ) {
-			// We need to use a temporary file because piping from cURL to tar is flaky
-			// on MinGW (and probably in other environments too).
 			$temp = Utils\get_temp_dir() . uniqid( 'wp_' ) . ".{$extension}";
 			register_shutdown_function(
 				function () use ( $temp ) {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -230,12 +230,8 @@ class Core_Command extends WP_CLI_Command {
 				$version = 'nightly';
 			}
 
-			// Nightly builds and skip content are only available in .zip format.
-			$extension = ( ( 'nightly' === $version ) || $skip_content )
-				? 'zip'
-				: 'tar.gz';
-
-			$download_url = $this->get_download_url( $version, $locale, $extension );
+			$extension    = 'zip';
+			$download_url = $this->get_download_url( $version, $locale );
 		} else {
 			$wp_org_api = new WpOrgApi( [ 'insecure' => $insecure ] );
 			try {
@@ -256,9 +252,6 @@ class Core_Command extends WP_CLI_Command {
 			}
 			$version      = $offer['current'];
 			$download_url = $offer['download'];
-			if ( ! $skip_content ) {
-				$download_url = str_replace( '.zip', '.tar.gz', $download_url );
-			}
 		}
 
 		if ( 'nightly' === $version && 'en_US' !== $locale ) {
@@ -277,17 +270,9 @@ class Core_Command extends WP_CLI_Command {
 			WP_CLI::log( "Downloading WordPress {$version} ({$locale})..." );
 		}
 
-		$path_parts = pathinfo( $download_url );
-		$extension  = 'tar.gz';
-		if ( isset( $path_parts['extension'] ) && 'zip' === $path_parts['extension'] ) {
-			$extension = 'zip';
-			if ( $extract && ! class_exists( 'ZipArchive' ) ) {
-				WP_CLI::error( 'Extracting a zip file requires ZipArchive.' );
-			}
-		}
-
-		if ( $skip_content && 'zip' !== $extension ) {
-			WP_CLI::error( 'Skip content is only available for ZIP files.' );
+		$extension = 'zip';
+		if ( $extract && ! class_exists( 'ZipArchive' ) ) {
+			WP_CLI::error( 'Extracting a zip file requires ZipArchive.' );
 		}
 
 		$cache = WP_CLI::get_cache();
@@ -1652,21 +1637,16 @@ EOT;
 	}
 
 	/**
-	 * Gets download url based on version, locale and desired file type.
+	 * Gets download url based on version and locale.
 	 *
 	 * @param $version
 	 * @param string $locale
-	 * @param string $file_type
 	 * @return string
 	 */
-	private function get_download_url( $version, $locale = 'en_US', $file_type = 'zip' ) {
+	private function get_download_url( $version, $locale = 'en_US' ) {
 
 		if ( 'nightly' === $version ) {
-			if ( 'zip' === $file_type ) {
-				return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
-			} else {
-				WP_CLI::error( 'Nightly builds are only available in .zip format.' );
-			}
+			return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
 		}
 
 		$locale_subdomain = 'en_US' === $locale ? '' : substr( $locale, 0, 2 ) . '.';
@@ -1676,7 +1656,7 @@ EOT;
 			$version = substr( $version, 0, -2 );
 		}
 
-		return "https://{$locale_subdomain}wordpress.org/wordpress-{$version}{$locale_suffix}.{$file_type}";
+		return "https://{$locale_subdomain}wordpress.org/wordpress-{$version}{$locale_suffix}.zip";
 	}
 
 	/**
@@ -1722,7 +1702,7 @@ EOT;
 			) {
 				return [
 					'current'  => $translation['version'],
-					'download' => $this->get_download_url( $translation['version'], $locale, 'zip' ),
+					'download' => $this->get_download_url( $translation['version'], $locale ),
 				];
 			}
 		}

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -230,7 +230,6 @@ class Core_Command extends WP_CLI_Command {
 				$version = 'nightly';
 			}
 
-			$extension    = 'zip';
 			$download_url = $this->get_download_url( $version, $locale );
 		} else {
 			$wp_org_api = new WpOrgApi( [ 'insecure' => $insecure ] );

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -271,9 +271,6 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		$extension = 'zip';
-		if ( $extract && ! class_exists( 'ZipArchive' ) ) {
-			WP_CLI::error( 'Extracting a zip file requires ZipArchive.' );
-		}
 
 		$cache = WP_CLI::get_cache();
 		if ( $from_url ) {


### PR DESCRIPTION
Alternative approach for addressing https://github.com/wp-cli/wp-cli/issues/6320, at least partially (one can still manually specify a tar.gz URL).

I tried to find why tar was added in favor of zip and it appears it was done in https://github.com/wp-cli/wp-cli/commit/0723df10f0cdb9984cb455dd464b1e6b5d03d8ac because of this comment: https://github.com/wp-cli/wp-cli/pull/144#issuecomment-7148901

So not really something that's applicable anymore nowadays.

Fixes #67