### PR TITLE
Detect file extension from downloaded archives

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -556,3 +556,40 @@ Feature: Download WordPress
       Success:
       """
 
+  Scenario: Extracts provided tar.gz files
+    Given an empty directory
+
+    When I run `wp core download https://downloads.wordpress.org/release/wordpress-7.0.tar.gz --force`
+    Then the {RUN_DIR} directory should contain:
+    """
+    index.php
+    license.txt
+    """
+
+  Scenario: Extracts provided zip files
+    Given an empty directory
+
+    When I run `wp core download https://downloads.wordpress.org/release/wordpress-7.0.zip --force`
+    Then the {RUN_DIR} directory should contain:
+    """
+    index.php
+    license.txt
+    """
+
+  Scenario: Error when downloading an unsupported archive format
+    Given an empty directory
+    And that HTTP requests to http://example.com/unsupported.txt will respond with:
+      """
+      HTTP/1.1 200 OK
+      Content-Type: text/plain
+
+      This is not a zip or tarball file.
+      """
+
+    When I try `wp core download http://example.com/unsupported.txt --force`
+    Then STDERR should contain:
+      """
+      Error: Unsupported archive format. The downloaded file is not a valid zip or tar.gz archive.
+      """
+    And the return code should be 1
+

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -561,20 +561,20 @@ Feature: Download WordPress
 
     When I run `wp core download https://downloads.wordpress.org/release/wordpress-7.0.tar.gz --force`
     Then the {RUN_DIR} directory should contain:
-    """
-    index.php
-    license.txt
-    """
+      """
+      index.php
+      license.txt
+      """
 
   Scenario: Extracts provided zip files
     Given an empty directory
 
     When I run `wp core download https://downloads.wordpress.org/release/wordpress-7.0.zip --force`
     Then the {RUN_DIR} directory should contain:
-    """
-    index.php
-    license.txt
-    """
+      """
+      index.php
+      license.txt
+      """
 
   Scenario: Error when downloading an unsupported archive format
     Given an empty directory

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -322,6 +322,10 @@ class Core_Command extends WP_CLI_Command {
 				WP_CLI::error( "Couldn't access download URL (HTTP code {$response->status_code})." );
 			}
 
+			if ( ! file_exists( $temp ) || ! is_readable( $temp ) ) {
+				WP_CLI::error( "Downloaded file could not be written to or read from disk: {$temp}" );
+			}
+
 			$extension = '';
 			if ( file_exists( $temp ) ) {
 				$mime = function_exists( 'mime_content_type' ) ? mime_content_type( $temp ) : '';

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -368,18 +368,19 @@ class Core_Command extends WP_CLI_Command {
 			$actual_temp = substr( $temp, 0, -4 ) . ".{$extension}";
 			if ( ! rename( $temp, $actual_temp ) ) {
 				// Fallback to copy + unlink.
-				if ( copy( $temp, $actual_temp ) ) {
-					$old_temp = $temp;
-					$temp     = $actual_temp;
-					if ( ! unlink( $old_temp ) ) {
-						register_shutdown_function(
-							function () use ( $old_temp ) {
-								if ( file_exists( $old_temp ) ) {
-									unlink( $old_temp );
-								}
+				if ( ! copy( $temp, $actual_temp ) ) {
+					WP_CLI::error( 'Failed to copy the downloaded file.' );
+				}
+				$old_temp = $temp;
+				$temp     = $actual_temp;
+				if ( ! unlink( $old_temp ) ) {
+					register_shutdown_function(
+						function () use ( $old_temp ) {
+							if ( file_exists( $old_temp ) ) {
+								unlink( $old_temp );
 							}
-						);
-					}
+						}
+					);
 				}
 			} else {
 				$temp = $actual_temp;

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -342,6 +342,19 @@ class Core_Command extends WP_CLI_Command {
 						}
 					}
 				}
+
+				// Deep validation for tar.gz archives: verify ustar magic string in decompressed stream.
+				if ( 'tar.gz' === $extension && function_exists( 'gzopen' ) ) {
+					// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Silence potential gzopen warnings on corrupt streams.
+					$gz = @gzopen( $temp, 'rb' );
+					if ( $gz ) {
+						$header = gzread( $gz, 262 );
+						gzclose( $gz );
+						if ( ! is_string( $header ) || 'ustar' !== substr( $header, 257, 5 ) ) {
+							$extension = '';
+						}
+					}
+				}
 			}
 
 			if ( ! in_array( $extension, [ 'zip', 'tar.gz' ], true ) ) {
@@ -349,7 +362,15 @@ class Core_Command extends WP_CLI_Command {
 			}
 
 			$actual_temp = substr( $temp, 0, -4 ) . ".{$extension}";
-			if ( rename( $temp, $actual_temp ) ) {
+			if ( ! rename( $temp, $actual_temp ) ) {
+				// Fallback to copy + unlink.
+				if ( copy( $temp, $actual_temp ) ) {
+					unlink( $temp );
+					$temp = $actual_temp;
+				} else {
+					WP_CLI::error( 'Failed to rename the downloaded temporary file.' );
+				}
+			} else {
 				$temp = $actual_temp;
 			}
 

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -346,16 +346,18 @@ class Core_Command extends WP_CLI_Command {
 				}
 			}
 
-			// Deep validation for tar.gz archives: verify ustar magic string in decompressed stream.
+			// Deep validation for tar.gz archives: verify it's a valid, readable gzip stream.
 			if ( 'tar.gz' === $extension && function_exists( 'gzopen' ) ) {
 				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Silence potential gzopen warnings on corrupt streams.
 				$gz = @gzopen( $temp, 'rb' );
 				if ( $gz ) {
 					$header = gzread( $gz, 262 );
 					gzclose( $gz );
-					if ( ! is_string( $header ) || 'ustar' !== substr( $header, 257, 5 ) ) {
+					if ( ! is_string( $header ) || strlen( $header ) < 1 ) {
 						$extension = '';
 					}
+				} else {
+					$extension = '';
 				}
 			}
 
@@ -367,10 +369,17 @@ class Core_Command extends WP_CLI_Command {
 			if ( ! rename( $temp, $actual_temp ) ) {
 				// Fallback to copy + unlink.
 				if ( copy( $temp, $actual_temp ) ) {
-					unlink( $temp );
-					$temp = $actual_temp;
-				} else {
-					WP_CLI::error( 'Failed to rename the downloaded temporary file.' );
+					$old_temp = $temp;
+					$temp     = $actual_temp;
+					if ( ! unlink( $old_temp ) ) {
+						register_shutdown_function(
+							function () use ( $old_temp ) {
+								if ( file_exists( $old_temp ) ) {
+									unlink( $old_temp );
+								}
+							}
+						);
+					}
 				}
 			} else {
 				$temp = $actual_temp;

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -297,11 +297,11 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		if ( ! $cache_file || $bad_cache ) {
-			$temp = Utils\get_temp_dir() . uniqid( 'wp_' ) . ".{$extension}";
+			$temp = Utils\get_temp_dir() . uniqid( 'wp_' ) . '.tmp';
 			register_shutdown_function(
-				function () use ( $temp ) {
+				function () use ( &$temp ) {
 					if ( file_exists( $temp ) ) {
-						unlink( $temp );
+						@unlink( $temp );
 					}
 				}
 			);
@@ -320,6 +320,37 @@ class Core_Command extends WP_CLI_Command {
 				WP_CLI::error( 'Release not found. Double-check locale or version.' );
 			} elseif ( 20 !== (int) substr( (string) $response->status_code, 0, 2 ) ) {
 				WP_CLI::error( "Couldn't access download URL (HTTP code {$response->status_code})." );
+			}
+
+			$extension = '';
+			if ( file_exists( $temp ) ) {
+				$mime = function_exists( 'mime_content_type' ) ? mime_content_type( $temp ) : '';
+				if ( 'application/zip' === $mime || 'application/x-zip-compressed' === $mime ) {
+					$extension = 'zip';
+				} elseif ( 'application/x-gzip' === $mime || 'application/gzip' === $mime ) {
+					$extension = 'tar.gz';
+				} else {
+					// Fallback to magic bytes.
+					$handle = @fopen( $temp, 'rb' );
+					if ( $handle ) {
+						$bytes = fread( $handle, 2 );
+						fclose( $handle );
+						if ( 'PK' === $bytes ) {
+							$extension = 'zip';
+						} elseif ( "\x1f\x8b" === $bytes ) {
+							$extension = 'tar.gz';
+						}
+					}
+				}
+			}
+
+			if ( ! in_array( $extension, [ 'zip', 'tar.gz' ], true ) ) {
+				WP_CLI::error( 'Unsupported archive format. The downloaded file is not a valid zip or tar.gz archive.' );
+			}
+
+			$actual_temp = substr( $temp, 0, -4 ) . ".{$extension}";
+			if ( rename( $temp, $actual_temp ) ) {
+				$temp = $actual_temp;
 			}
 
 			if ( 'nightly' !== $version ) {

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -327,36 +327,34 @@ class Core_Command extends WP_CLI_Command {
 			}
 
 			$extension = '';
-			if ( file_exists( $temp ) ) {
-				$mime = function_exists( 'mime_content_type' ) ? mime_content_type( $temp ) : '';
-				if ( 'application/zip' === $mime || 'application/x-zip-compressed' === $mime ) {
-					$extension = 'zip';
-				} elseif ( 'application/x-gzip' === $mime || 'application/gzip' === $mime ) {
-					$extension = 'tar.gz';
-				} else {
-					// Fallback to magic bytes.
-					$handle = @fopen( $temp, 'rb' );
-					if ( $handle ) {
-						$bytes = fread( $handle, 2 );
-						fclose( $handle );
-						if ( 'PK' === $bytes ) {
-							$extension = 'zip';
-						} elseif ( "\x1f\x8b" === $bytes ) {
-							$extension = 'tar.gz';
-						}
+			$mime      = function_exists( 'mime_content_type' ) ? mime_content_type( $temp ) : '';
+			if ( 'application/zip' === $mime || 'application/x-zip-compressed' === $mime ) {
+				$extension = 'zip';
+			} elseif ( 'application/x-gzip' === $mime || 'application/gzip' === $mime ) {
+				$extension = 'tar.gz';
+			} else {
+				// Fallback to magic bytes.
+				$handle = @fopen( $temp, 'rb' );
+				if ( $handle ) {
+					$bytes = fread( $handle, 2 );
+					fclose( $handle );
+					if ( 'PK' === $bytes ) {
+						$extension = 'zip';
+					} elseif ( "\x1f\x8b" === $bytes ) {
+						$extension = 'tar.gz';
 					}
 				}
+			}
 
-				// Deep validation for tar.gz archives: verify ustar magic string in decompressed stream.
-				if ( 'tar.gz' === $extension && function_exists( 'gzopen' ) ) {
-					// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Silence potential gzopen warnings on corrupt streams.
-					$gz = @gzopen( $temp, 'rb' );
-					if ( $gz ) {
-						$header = gzread( $gz, 262 );
-						gzclose( $gz );
-						if ( ! is_string( $header ) || 'ustar' !== substr( $header, 257, 5 ) ) {
-							$extension = '';
-						}
+			// Deep validation for tar.gz archives: verify ustar magic string in decompressed stream.
+			if ( 'tar.gz' === $extension && function_exists( 'gzopen' ) ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Silence potential gzopen warnings on corrupt streams.
+				$gz = @gzopen( $temp, 'rb' );
+				if ( $gz ) {
+					$header = gzread( $gz, 262 );
+					gzclose( $gz );
+					if ( ! is_string( $header ) || 'ustar' !== substr( $header, 257, 5 ) ) {
+						$extension = '';
 					}
 				}
 			}

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -301,7 +301,7 @@ class Core_Command extends WP_CLI_Command {
 			register_shutdown_function(
 				function () use ( &$temp ) {
 					if ( file_exists( $temp ) ) {
-						@unlink( $temp );
+						unlink( $temp );
 					}
 				}
 			);


### PR DESCRIPTION
This is sort of a follow-up to #333 but actually fixes a bug that was there before. There was no file extension verification in there at all, we just treated any provided archive URL as a zip or tar.gz archive. 