### PR TITLE
Escape URL parameter in update-db and check-update-db network commands

### DIFF
--- a/features/core-check-update-db.feature
+++ b/features/core-check-update-db.feature
@@ -98,3 +98,12 @@ Feature: Check if WordPress database update is needed
       Error: This is not a multisite installation.
       """
     And the return code should be 1
+
+  Scenario: Check database update on network installation safely handles site domain/path with special characters
+    Given a WP multisite install
+    And I run `wp db query "INSERT INTO wp_blogs (site_id, domain, path, registered, last_updated) VALUES (1, 'example.com', '/x\\\$(touch /tmp/wpcli_test_check_db_marker)/', NOW(), NOW());"`
+
+    When I run `wp core check-update-db --network`
+    Then the return code should be 0
+    And the /tmp/wpcli_test_check_db_marker file should not exist
+

--- a/src/Core_Command.php
+++ b/src/Core_Command.php
@@ -1510,7 +1510,7 @@ EOT;
 			foreach ( $it as $blog ) {
 				++$total;
 				$url = $blog->domain . $blog->path;
-				$cmd = "--url={$url} core check-update-db";
+				$cmd = Utils\esc_cmd( '--url=%s core check-update-db', $url );
 
 				/**
 				 * @var object{stdout: string, stderr: string, return_code: int} $process
@@ -1628,7 +1628,7 @@ EOT;
 			foreach ( $it as $blog ) {
 				++$total;
 				$url = $blog->domain . $blog->path;
-				$cmd = "--url={$url} core update-db";
+				$cmd = Utils\esc_cmd( '--url=%s core update-db', $url );
 				if ( $dry_run ) {
 					$cmd .= ' --dry-run';
 				}


### PR DESCRIPTION
Apply some slight hardening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multisite database checks and updates for site paths containing shell-special characters.
  * Prevented site URL content from being interpreted as command syntax during network operations.
  * Added coverage to verify successful execution without creating unintended files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->