### PR TITLE
Do not use deprecated `plugin status` command in tests

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -271,13 +271,11 @@ Feature: Manage WordPress installation
       """
     And the return code should be 1
 
-  # SQLite compat blocked by https://github.com/wp-cli/wp-cli-tests/pull/188.
-  @require-mysql
   Scenario: Custom wp-content directory
     Given a WP install
     And a custom wp-content directory
 
-    When I run `wp plugin status akismet`
+    When I run `wp plugin get akismet`
     Then STDOUT should not be empty
 
   Scenario: User defined in wp-cli.yml


### PR DESCRIPTION
Also ensures the test runs with SQLite, as upstream blocker no longer exists

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated custom content directory verification to use a more reliable Akismet plugin check.
  * Expanded scenario compatibility beyond MySQL-only environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->