### PR TITLE
Mock Version Check API responses in core update tests

### DIFF
--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -5,13 +5,26 @@ Feature: Check for more recent versions
   Scenario: Check for update via Version Check API
     Given a WP install
     And I try `wp theme install twentytwenty --activate`
+    # The Version Check API only offers in-branch (minor) updates to a subset of
+    # sites, bucketed by the site URL, so the response is mocked to stay stable.
+    And that HTTP requests to https://api.wordpress.org/core/version-check/1.7/ will respond with:
+      """
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {"offers":[{"response":"upgrade","download":"https://downloads.wordpress.org/release/wordpress-6.0.zip","locale":"en_US","packages":{"full":"https://downloads.wordpress.org/release/wordpress-6.0.zip","no_content":false,"new_bundled":false,"partial":false,"rollback":false},"current":"6.0","version":"6.0","php_version":"5.6.20","mysql_version":"5.0"},{"response":"autoupdate","download":"https://downloads.wordpress.org/release/wordpress-5.8.1.zip","locale":"en_US","packages":{"full":"https://downloads.wordpress.org/release/wordpress-5.8.1.zip","no_content":false,"new_bundled":false,"partial":"https://downloads.wordpress.org/release/wordpress-5.8.1-partial-0.zip","rollback":false},"current":"5.8.1","version":"5.8.1","php_version":"5.6.20","mysql_version":"5.0"}]}
+      """
 
     When I run `wp core download --version=5.8 --force`
     Then STDOUT should not be empty
 
     When I run `wp core check-update --format=csv`
-    Then STDOUT should match #{WP_VERSION-latest},major,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-latest}.zip#
-    And STDOUT should match #{WP_VERSION-5.8-latest},minor,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip#
+    Then STDOUT should be:
+      """
+      version,update_type,package_url
+      5.8.1,minor,https://downloads.wordpress.org/release/wordpress-5.8.1-partial-0.zip
+      6.0,major,https://downloads.wordpress.org/release/wordpress-6.0.zip
+      """
 
     When I run `wp core check-update --format=count`
     Then STDOUT should be:
@@ -20,7 +33,11 @@ Feature: Check for more recent versions
       """
 
     When I run `wp core check-update --major --format=csv`
-    Then STDOUT should match #{WP_VERSION-latest},major,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-latest}.zip#
+    Then STDOUT should be:
+      """
+      version,update_type,package_url
+      6.0,major,https://downloads.wordpress.org/release/wordpress-6.0.zip
+      """
 
     When I run `wp core check-update --major --format=count`
     Then STDOUT should be:
@@ -29,7 +46,11 @@ Feature: Check for more recent versions
       """
 
     When I run `wp core check-update --minor --format=csv`
-    Then STDOUT should match #{WP_VERSION-5.8-latest},minor,https://downloads.(w|wordpress).org/release/wordpress-{WP_VERSION-5.8-latest}-partial-0.zip#
+    Then STDOUT should be:
+      """
+      version,update_type,package_url
+      5.8.1,minor,https://downloads.wordpress.org/release/wordpress-5.8.1-partial-0.zip
+      """
 
     When I run `wp core check-update --minor --format=count`
     Then STDOUT should be:

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -100,6 +100,16 @@ Feature: Update WordPress core
   Scenario: Update to the latest minor release (PHP 7.2 compatible with WP >= 4.9)
     Given a WP install
     And I try `wp theme install twentytwenty --activate`
+    # The Version Check API only offers in-branch (minor) updates to a subset of
+    # sites, bucketed by the site URL, so the response is mocked to stay stable.
+    # The packages are real, so the update itself is still performed for real.
+    And that HTTP requests to https://api.wordpress.org/core/version-check/1.7/ will respond with:
+      """
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {"offers":[{"response":"upgrade","download":"https://downloads.wordpress.org/release/wordpress-6.3.zip","locale":"en_US","packages":{"full":"https://downloads.wordpress.org/release/wordpress-6.3.zip","no_content":false,"new_bundled":false,"partial":false,"rollback":false},"current":"6.3","version":"6.3","php_version":"7.0.0","mysql_version":"5.0"},{"response":"autoupdate","download":"https://downloads.wordpress.org/release/wordpress-6.2.11.zip","locale":"en_US","packages":{"full":"https://downloads.wordpress.org/release/wordpress-6.2.11.zip","no_content":false,"new_bundled":false,"partial":false,"rollback":false},"current":"6.2.11","version":"6.2.11","php_version":"7.0.0","mysql_version":"5.0"}]}
+      """
 
     When I run `wp core download --version=6.2.5 --force`
     Then STDOUT should contain:
@@ -111,7 +121,7 @@ Feature: Update WordPress core
     When I try `wp core update --minor`
     Then STDOUT should contain:
       """
-      Updating to version {WP_VERSION-6.2-latest}
+      Updating to version 6.2.11
       """
     And STDOUT should contain:
       """
@@ -128,7 +138,7 @@ Feature: Update WordPress core
     When I run `wp core version`
     Then STDOUT should be:
       """
-      {WP_VERSION-6.2-latest}
+      6.2.11
       """
 
   # This test downgrades to an older WordPress version, but the SQLite plugin requires 6.4+
@@ -547,6 +557,16 @@ Feature: Update WordPress core
   Scenario: Update WordPress locale when using --minor
     Given a WP install
     And an empty cache
+    # The Version Check API only offers in-branch (minor) updates to a subset of
+    # sites, bucketed by the site URL, so the response is mocked to stay stable.
+    # The packages are real, so the update itself is still performed for real.
+    And that HTTP requests to https://api.wordpress.org/core/version-check/1.7/ will respond with:
+      """
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {"offers":[{"response":"autoupdate","download":"https://downloads.wordpress.org/release/wordpress-6.5.10.zip","locale":"en_US","packages":{"full":"https://downloads.wordpress.org/release/wordpress-6.5.10.zip","no_content":false,"new_bundled":false,"partial":false,"rollback":false},"current":"6.5.10","version":"6.5.10","php_version":"7.0.0","mysql_version":"5.0"}]}
+      """
 
     # Using `try` in case there are checksum warnings.
     When I try `wp core download --version=6.5 --locale=de_DE --force`


### PR DESCRIPTION
## Summary
This PR updates the core check-update and core update feature tests to mock the WordPress Version Check API responses, replacing dynamic version placeholders with fixed, stable test data.

## Key Changes
- **Mock API responses**: Added HTTP mocking for `https://api.wordpress.org/core/version-check/1.7/` endpoint in three test scenarios to provide consistent, predictable version data
- **Replace dynamic assertions**: Converted regex-based assertions using version placeholders (e.g., `{WP_VERSION-latest}`, `{WP_VERSION-5.8-latest}`) to exact string matching with hardcoded version numbers
- **Stabilize test output**: Changed from pattern matching to exact output verification in CSV format assertions, ensuring tests produce deterministic results regardless of the actual latest WordPress versions available
- **Updated version expectations**: 
  - `core-check-update.feature`: Tests now expect versions 5.8.1 (minor) and 6.0 (major)
  - `core-update.feature`: Tests now expect versions 6.2.11 (minor) and 6.3 (major), and 6.5.10 for locale tests

## Implementation Details
The mocked API responses include realistic WordPress release data with proper JSON structure, including download URLs, package information, PHP/MySQL version requirements, and response types (upgrade/autoupdate). This approach ensures tests remain stable and reproducible while still validating the actual update functionality with real packages.

https://claude.ai/code/session_011sevK5u2P9Egf2Vae5QRu6